### PR TITLE
Additional attributes for newrelic-infra.yml template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,4 +13,7 @@ Pull requests should:
 
 By contributing to this project you agree that you are granting New Relic a non-exclusive, non-revokable, no-cost license to use the code, algorithms, patents, and ideas in that code in our products if we so choose. You also agree the code is provided as-is and you provide no warranties as to its fitness or correctness for any purpose
 
+Contributors:
+Robert Hak <robert.hak @ iacapps.com>
+
 Copyright (c) 2016 New Relic, Inc. All rights reserved.

--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ The `agent_linux` recipe:
 See `attributes/defaults.rb` for default values.
 
 - `node['newrelic-infra']['license_key']` - Your New Relic license key.
+- `node['newrelic-infra']['log_file']` - Override system log file location by providing Log path and file name.
+- `node['newrelic-infra']['verbose']` - Log verbosity setting. Type: String
+- `node['newrelic-infra']['proxy']` - Your proxy url if required.
 - `node['newrelic-infra']['agent_action']` - `newrelic-infra` package actions. Values:
   - `'install'`: _(Default)_ Installs package. If `'agent_version'` is specified, installs specific version.
   - `'upgrade'`: Installs package and/or ensures it's the latest version.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -5,3 +5,7 @@ default['newrelic-infra']['agent_action'] = 'install'
 default['newrelic-infra']['agent_version'] = nil
 
 default['newrelic-infra']['license_key'] = nil
+default['newrelic-infra']['display_name'] = nil
+default['newrelic-infra']['proxy'] = nil
+default['newrelic-infra']['verbose'] = nil
+default['newrelic-infra']['log_file'] = nil

--- a/recipes/agent_linux.rb
+++ b/recipes/agent_linux.rb
@@ -29,9 +29,9 @@ when 'debian'
   end
 
   # Update APT repo
-	execute 'apt-get update' do
-		command 'apt-get update'
-	end
+#	execute 'apt-get update' do
+#		command 'apt-get update'
+#	end
 when 'rhel'
   # Add Yum repo
   rhel_version = node['platform_version'].to_i
@@ -71,7 +71,6 @@ service "newrelic-infra" do
   action [:enable, :start]
 end
 
-
 # Lay down newrelic-infra agent config
 template '/etc/newrelic-infra.yml' do
   source 'newrelic-infra.yml.erb'
@@ -79,7 +78,11 @@ template '/etc/newrelic-infra.yml' do
   group 'root'
   mode '00644'
   variables(
-    'license_key' => node['newrelic-infra']['license_key']
+    'license_key' => node['newrelic-infra']['license_key'],
+    'display_name' => node['newrelic-infra']['display_name'],
+    'log_file' => node['newrelic-infra']['log_file'],
+    'verbose' => node['newrelic-infra']['verbose'],
+    'proxy' => node['newrelic-infra']['proxy']
   )
   notifies :restart, 'service[newrelic-infra]', :delayed
 end

--- a/templates/default/newrelic-infra.yml.erb
+++ b/templates/default/newrelic-infra.yml.erb
@@ -1,1 +1,13 @@
 license_key: <%= @license_key %>
+<% unless @display_name.nil? || @display_name.empty? -%>
+display_name: <%= @display_name %>
+<% end -%>
+<% unless @log_file.nil? || @log_file.empty? -%>
+log_file: <%= @log_file %>
+<% end -%>
+<% unless @verbose.nil? || @verbose.empty? -%>
+verbose: <%= @verbose %>
+<% end -%>
+<% unless @proxy.nil? || @proxy.empty? -%>
+proxy: <%= @proxy %>
+<% end -%>


### PR DESCRIPTION
Users are currently required to wrap around the newrelic-infra.yml template as additional common configurations are not available. This request adds optional the listed attributes for the newrelic-infra.yml template. 

Attribute: display_name
Type: String
Default: none

Attribute: log_path
Type: String
Default: none

Attribute: verbose
Type: String
Default: none

Attribute: proxy
Type: String
Default: none

Attributes set as nil or empty string will be ignored by the template.
