### PR TITLE
Add Amazon Linux support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This cookbook installs and configures the New Relic Infrastructure agent.
 - RHEL
   - CentOS 7
   - CentOS 6
-  - Amazon Linux 2016.03
+  - Amazon Linux (all versions)
 - Ubuntu
   - 16 Xenial
   - 14 Trusty

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This cookbook installs and configures the New Relic Infrastructure agent.
 - RHEL
   - CentOS 7
   - CentOS 6
+  - Amazon Linux 2016.03
 - Ubuntu
   - 16 Xenial
   - 14 Trusty

--- a/recipes/agent.rb
+++ b/recipes/agent.rb
@@ -13,11 +13,18 @@ when 'debian'
   # TODO: Add better debian platform/version detection
   include_recipe 'newrelic-infra::agent_linux'
 when 'rhel'
-  case node['platform_version']
-  when /^6/, /^7/
+  case node['platform']
+  when 'centos'
+    case node['platform_version']
+    when /^6/, /^7/
+      include_recipe 'newrelic-infra::agent_linux'
+    else
+      raise 'The New Relic Infrastructure agent is not currently supported on this platform version'
+    end
+  when 'amazon'
     include_recipe 'newrelic-infra::agent_linux'
   else
-    raise 'The New Relic Infrastructure agent is not currently supported on this platform version'
+    raise 'The New Relic Infrastructure agent is not currently supported on this platform'
   end
 when 'windows'
   include_recipe 'newrelic-infra::agent_windows'

--- a/recipes/agent_linux.rb
+++ b/recipes/agent_linux.rb
@@ -39,7 +39,7 @@ when 'rhel'
     rhel_version = node['platform_version'].to_i
   when 'amazon'
     case node['platform_version'].to_i
-    when 2013, 2014, 2015, 2016
+    when 2013, 2014, 2015, 2016, 2017
       rhel_version = 6
     end
   end

--- a/recipes/agent_linux.rb
+++ b/recipes/agent_linux.rb
@@ -34,7 +34,16 @@ when 'debian'
 	end
 when 'rhel'
   # Add Yum repo
-  rhel_version = node['platform_version'].to_i
+  case node['platform']
+  when 'centos'
+    rhel_version = node['platform_version'].to_i
+  when 'amazon'
+    case node['platform_version'].to_i
+    when 2013, 2014, 2015, 2016
+      rhel_version = 6
+    end
+  end
+
   yum_repository 'newrelic-infra' do
     description "New Relic Infrastructure"
     baseurl "https://download.newrelic.com/infrastructure_agent/linux/yum/el/#{rhel_version}/x86_64"


### PR DESCRIPTION
This cookbook does not work on Amazon Linux currently (you get the error "The New Relic Infrastructure agent is not currently supported on this platform version"). This PR fixes that.

I tested and verified that this works by doing a successful chef run on an Amazon Linux 2016.03.02 EC2 instance, including the default recipe from this cookbook in the run list.

I also did a regression test and verified that it still works for CentOS (I tested using CentOS 7.1)

The code checks for and allows Amazon Linux 2013, 2014, 2015, 2016, and 2017 (inspired by [this method in the httpd cookbook](https://github.com/chef-cookbooks/httpd/blob/v0.4.5/libraries/helpers_rhel.rb#L32)), but I only tested with 2016 and 2017. If that's a problem, I can change it. But [this page](https://docs.newrelic.com/docs/infrastructure/new-relic-infrastructure/getting-started/compatibility-requirements-new-relic-infrastructure#operating-systems) says that all versions of Amazon Linux are supported by New Relic Infrastructure, so it sounds like it's ok.