### PR TITLE
Fix Berks Deprecation Warnings

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,3 @@
-site :opscode
+source 'https://supermarket.chef.io'
 
 metadata

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,3 +19,4 @@ Copyright (c) 2017 New Relic, Inc. All rights reserved.
 
 * David Lanner (@dlanner)
 * Robert Hak <robert.hak @ iacapps.com>
+* Brandon Pierce <brandon.pierce@sturdynetworks.com>


### PR DESCRIPTION
The purpose of this PR is to clear up the following deprecation warning when attempting to generate the Berks lockfile via `berks install`:

```none
DEPRECATED: Your Berksfile contains a site location pointing to the Opscode Community Site (site :opscode). Site locations have been replaced by the source location. Change this to: 'source "https://supermarket.chef.io"' to remove this warning. For more information visit https://github.com/berkshelf/berkshelf/wiki/deprecated-locations
Resolving cookbook dependencies...
Fetching 'newrelic-infra' from source at .
Using newrelic-infra (0.0.1) from source at .
```


After the change to `Berksfile` the warnings no longer exist:

```none
Resolving cookbook dependencies...
Fetching 'newrelic-infra' from source at .
Fetching cookbook index from https://supermarket.chef.io...
Using newrelic-infra (0.0.1) from source at .
```

For the record I'm on `5.2.0` of Berks:

```none
$ berks --version
5.2.0
```

Although this deprecation happened quite some time ago:

* https://github.com/berkshelf/berkshelf/wiki/deprecated-locations


Here is the output of `kitchen test`

```none
-----> Starting Kitchen (v1.14.2)
-----> Cleaning up any prior instances of <default-ubuntu-1204>
-----> Cleaning up any prior instances of <default-ubuntu-1404>
-----> Cleaning up any prior instances of <default-centos-68>
-----> Cleaning up any prior instances of <default-centos-72>
-----> Destroying <default-ubuntu-1204>...
-----> Destroying <default-centos-68>...
-----> Destroying <default-ubuntu-1404>...
-----> Destroying <default-centos-72>...
       Finished destroying <default-centos-68> (0m0.00s).
       Finished destroying <default-ubuntu-1204> (0m0.00s).
-----> Testing <default-centos-68>
-----> Creating <default-centos-68>...
       Finished destroying <default-ubuntu-1404> (0m0.00s).
-----> Testing <default-ubuntu-1404>
-----> Creating <default-ubuntu-1404>...
-----> Testing <default-ubuntu-1204>
-----> Creating <default-ubuntu-1204>...
       Finished destroying <default-centos-72> (0m0.00s).
-----> Testing <default-centos-72>
-----> Creating <default-centos-72>...
       Vagrant detected both the ATLAS_TOKEN environment variable and a Vagrant login
       token are present on this system. The ATLAS_TOKEN environment variable takes
       precedence over the locally stored token. To remove this error, either unset
       the ATLAS_TOKEN environment variable or remove the login token stored on disk:

           ~/.vagrant.d/data/vagrant_login_token

       In general, the ATLAS_TOKEN is more preferred because it is respected by all
       HashiCorp products.
       Bringing machine 'default' up with 'virtualbox' provider...
       ==> default: Importing base box 'bento/centos-6.8'...
==> default: Matching MAC address for NAT networking...
       ==> default: Checking if box 'bento/centos-6.8' is up to date...
       ==> default: Setting the name of the VM: kitchen-infrastructure-agent-chef-fork-default-centos-68_default_1493822208285_67523
       ==> default: Clearing any previously set network interfaces...
       ==> default: Preparing network interfaces based on configuration...
           default: Adapter 1: nat
       ==> default: Forwarding ports...
           default: 22 (guest) => 2222 (host) (adapter 1)
       ==> default: Running 'pre-boot' VM customizations...
       ==> default: Booting VM...
       ==> default: Waiting for machine to boot. This may take a few minutes...
           default: SSH address: 127.0.0.1:2222
           default: SSH username: vagrant
           default: SSH auth method: private key
           default: Warning: Remote connection disconnect. Retrying...
           default: Warning: Connection reset. Retrying...
           default: Warning: Remote connection disconnect. Retrying...
           default:
           default: Vagrant insecure key detected. Vagrant will automatically replace
           default: this with a newly generated keypair for better security.
           default:
           default: Inserting generated public key within guest...
           default: Removing insecure key from the guest if it's present...
           default: Key inserted! Disconnecting and reconnecting using new SSH key...
       ==> default: Machine booted and ready!
       ==> default: Checking for guest additions in VM...
       ==> default: Setting hostname...
       ==> default: Mounting shared folders...
           default: /tmp/omnibus/cache => /Users/brandon/.kitchen/cache
       ==> default: Machine not provisioned because `--no-provision` is specified.
       [SSH] Established
       Vagrant instance <default-centos-68> created.
       Finished creating <default-centos-68> (0m47.53s).
-----> Converging <default-centos-68>...
       Preparing files for transfer
       Preparing dna.json
       Resolving cookbook dependencies with Berkshelf 5.2.0...
       Removing non-cookbook files before transfer
       Preparing solo.rb
-----> Installing Chef Omnibus (install only if missing)
       Downloading https://omnitruck.chef.io/install.sh to file /tmp/install.sh
       Trying wget...
       Download complete.
       el 6 x86_64
       Getting information for chef stable  for el...
       downloading https://omnitruck.chef.io/stable/chef/metadata?v=&p=el&pv=6&m=x86_64
         to file /tmp/install.sh.7529/metadata.txt
       trying wget...
       sha1	b92640edfce4b23788cfc6e201e862f985ed6873
       sha256	aa47e3da21416091e5cb80fd5a8e9172bc7971a228b522871d7276c915116d2f
       url	https://packages.chef.io/files/stable/chef/13.0.118/el/6/chef-13.0.118-1.el6.x86_64.rpm
       version	13.0.118
       downloaded metadata file looks valid...
       /tmp/omnibus/cache/chef-13.0.118-1.el6.x86_64.rpm already exists, verifiying checksum...
       Comparing checksum with sha256sum...
       checksum compare succeeded, using existing file!

       WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING

       You are installing an omnibus package without a version pin.  If you are installing
       on production servers via an automated process this is DANGEROUS and you will
       be upgraded without warning on new releases, even to new major releases.
       Letting the version float is only appropriate in desktop, test, development or
       CI/CD environments.

       WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING

       Installing chef
       installing with rpm...
       warning: /tmp/omnibus/cache/chef-13.0.118-1.el6.x86_64.rpm: Header V4 DSA/SHA1 Signature, key ID 83ef826a: NOKEY
       Bringing machine 'default' up with 'virtualbox' provider...
       ==> default: Box 'bento/ubuntu-14.04' could not be found. Attempting to find and install...
           default: Box Provider: virtualbox
           default: Box Version: >= 0
       Preparing...                ########################################### [100%]
       Vagrant detected both the ATLAS_TOKEN environment variable and a Vagrant login
       token are present on this system. The ATLAS_TOKEN environment variable takes
       precedence over the locally stored token. To remove this error, either unset
       the ATLAS_TOKEN environment variable or remove the login token stored on disk:

           ~/.vagrant.d/data/vagrant_login_token

       In general, the ATLAS_TOKEN is more preferred because it is respected by all
       HashiCorp products.
       ==> default: Loading metadata for box 'bento/ubuntu-14.04'
           default: URL: https://atlas.hashicorp.com/bento/ubuntu-14.04
       Vagrant detected both the ATLAS_TOKEN environment variable and a Vagrant login
       token are present on this system. The ATLAS_TOKEN environment variable takes
       precedence over the locally stored token. To remove this error, either unset
       the ATLAS_TOKEN environment variable or remove the login token stored on disk:

           ~/.vagrant.d/data/vagrant_login_token

       In general, the ATLAS_TOKEN is more preferred because it is respected by all
       HashiCorp products.
       ==> default: Adding box 'bento/ubuntu-14.04' (v2.3.5) for provider: virtualbox
           default: Downloading: https://atlas.hashicorp.com/bento/boxes/ubuntu-14.04/versions/2.3.5/providers/virtualbox.box
       ==> default: Box download is resuming from prior download progress
          1:chef                   ########################################### [100%]
       Thank you for installing Chef!
       Transferring files to <default-centos-68>
       Starting Chef Client, version 13.0.118
       Creating a new client identity for default-centos-68 using the validator key.
       resolving cookbooks for run list: ["newrelic-infra::default"]
       Synchronizing Cookbooks:
         - newrelic-infra (0.0.1)
       Installing Cookbook Gems:
       Compiling Cookbooks...
       Converging 5 resources
       Recipe: newrelic-infra::agent_linux
         * yum_repository[newrelic-infra] action create
           * template[/etc/yum.repos.d/newrelic-infra.repo] action create
             - create new file /etc/yum.repos.d/newrelic-infra.repo
             - update content in file /etc/yum.repos.d/newrelic-infra.repo from none to 199237
             --- /etc/yum.repos.d/newrelic-infra.repo	2017-05-03 14:37:36.798392232 +0000
             +++ /etc/yum.repos.d/.chef-newrelic-infra20170503-7635-dz1ogh.repo	2017-05-03 14:37:36.798392232 +0000
             @@ -1 +1,12 @@
             +# This file was generated by Chef
             +# Do NOT modify this file by hand.
             +
             +[newrelic-infra]
             +name=New Relic Infrastructure
             +baseurl=https://download.newrelic.com/infrastructure_agent/linux/yum/el/6/x86_64
             +enabled=1
             +fastestmirror_enabled=0
             +gpgcheck=1
             +gpgkey=https://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg
             +repo_gpgcheck=1
             - change mode from '' to '0644'
             - restore selinux security context
           * execute[yum clean metadata newrelic-infra] action run
             - execute yum clean metadata --disablerepo=* --enablerepo=newrelic-infra
           * execute[yum-makecache-newrelic-infra] action run
             - execute yum -q -y makecache --disablerepo=* --enablerepo=newrelic-infra
           * ruby_block[yum-cache-reload-newrelic-infra] action create
             - execute the ruby block yum-cache-reload-newrelic-infra
           * execute[yum clean metadata newrelic-infra] action nothing (skipped due to action :nothing)
           * execute[yum-makecache-newrelic-infra] action nothing (skipped due to action :nothing)
           * ruby_block[yum-cache-reload-newrelic-infra] action nothing (skipped due to action :nothing)

         * execute[Update Infra Yum repo] action run
           - execute yum -q makecache -y --disablerepo='*' --enablerepo='newrelic-infra'
Vagrant detected both the ATLAS_TOKEN environment variable and a Vagrant login
       token are present on this system. The ATLAS_TOKEN environment variable takes
       precedence over the locally stored token. To remove this error, either unset
       the ATLAS_TOKEN environment variable or remove the login token stored on disk:

           ~/.vagrant.d/data/vagrant_login_token

       In general, the ATLAS_TOKEN is more preferred because it is respected by all
       HashiCorp products.
       ==> default: Successfully added box 'bento/ubuntu-14.04' (v2.3.5) for 'virtualbox'!
       Vagrant detected both the ATLAS_TOKEN environment variable and a Vagrant login
       token are present on this system. The ATLAS_TOKEN environment variable takes
       precedence over the locally stored token. To remove this error, either unset
       the ATLAS_TOKEN environment variable or remove the login token stored on disk:

           ~/.vagrant.d/data/vagrant_login_token

       In general, the ATLAS_TOKEN is more preferred because it is respected by all
       HashiCorp products.
       ==> default: Importing base box 'bento/ubuntu-14.04'...
         * yum_package[newrelic-infra] action install
           - install version 1.0.682-1 of package newrelic-infra
         * service[newrelic-infra] action enable (up to date)
         * service[newrelic-infra] action start
           - start service service[newrelic-infra]
         * template[/etc/newrelic-infra.yml] action create
           - create new file /etc/newrelic-infra.yml
           - update content in file /etc/newrelic-infra.yml from none to ed63eb
           --- /etc/newrelic-infra.yml	2017-05-03 14:37:54.807392235 +0000
           +++ /etc/.chef-newrelic-infra20170503-7635-o4fk07.yml	2017-05-03 14:37:54.807392235 +0000
           @@ -1 +1,2 @@
           +license_key: REDACTED
           - change mode from '' to '0644'
           - change owner from '' to 'root'
           - change group from '' to 'root'
           - restore selinux security context
         * service[newrelic-infra] action restart
           - restart service service[newrelic-infra]

       Running handlers:
       Running handlers complete
       Chef Client finished, 10/14 resources updated in 22 seconds
       Finished converging <default-centos-68> (0m31.72s).
-----> Setting up <default-centos-68>...
       Finished setting up <default-centos-68> (0m0.00s).
-----> Verifying <default-centos-68>...
       Preparing files for transfer
       Transferring files to <default-centos-68>
       Finished verifying <default-centos-68> (0m0.00s).
-----> Destroying <default-centos-68>...
==> default: Matching MAC address for NAT networking...
       ==> default: Checking if box 'bento/ubuntu-14.04' is up to date...
       ==> default: Setting the name of the VM: kitchen-infrastructure-agent-chef-fork-default-ubuntu-1404_default_1493822282958_44190
       ==> default: Fixed port collision for 22 => 2222. Now on port 2200.
       ==> default: Clearing any previously set network interfaces...
       ==> default: Preparing network interfaces based on configuration...
           default: Adapter 1: nat
       ==> default: Forwarding ports...
           default: 22 (guest) => 2200 (host) (adapter 1)
       ==> default: Running 'pre-boot' VM customizations...
       ==> default: Booting VM...
       ==> default: Waiting for machine to boot. This may take a few minutes...
           default: SSH address: 127.0.0.1:2200
           default: SSH username: vagrant
           default: SSH auth method: private key
           default:
           default: Vagrant insecure key detected. Vagrant will automatically replace
           default: this with a newly generated keypair for better security.
           default:
           default: Inserting generated public key within guest...
           default: Removing insecure key from the guest if it's present...
           default: Key inserted! Disconnecting and reconnecting using new SSH key...
       ==> default: Machine booted and ready!
       ==> default: Checking for guest additions in VM...
       ==> default: Setting hostname...
       ==> default: Mounting shared folders...
           default: /tmp/omnibus/cache => /Users/brandon/.kitchen/cache
       ==> default: Machine not provisioned because `--no-provision` is specified.
       [SSH] Established
       Vagrant instance <default-ubuntu-1404> created.
       Finished creating <default-ubuntu-1404> (1m45.85s).
-----> Converging <default-ubuntu-1404>...
       Preparing files for transfer
       Preparing dna.json
       Resolving cookbook dependencies with Berkshelf 5.2.0...
       Removing non-cookbook files before transfer
       Preparing solo.rb
-----> Installing Chef Omnibus (install only if missing)
       Downloading https://omnitruck.chef.io/install.sh to file /tmp/install.sh
       Trying wget...
       Download complete.
       ubuntu 14.04 x86_64
       Getting information for chef stable  for ubuntu...
       downloading https://omnitruck.chef.io/stable/chef/metadata?v=&p=ubuntu&pv=14.04&m=x86_64
         to file /tmp/install.sh.1537/metadata.txt
       trying wget...
       sha1	da845676ff2e17b3049ca6e52541389318183f89
       sha256	650e80ad44584ca48716752d411989ab155845af4af7a50c530155d9718843eb
       url	https://packages.chef.io/files/stable/chef/13.0.118/ubuntu/14.04/chef_13.0.118-1_amd64.deb
       version	13.0.118
       downloaded metadata file looks valid...
       /tmp/omnibus/cache/chef_13.0.118-1_amd64.deb already exists, verifiying checksum...
       Comparing checksum with sha256sum...
       checksum compare succeeded, using existing file!

       WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING

       You are installing an omnibus package without a version pin.  If you are installing
       on production servers via an automated process this is DANGEROUS and you will
       be upgraded without warning on new releases, even to new major releases.
       Letting the version float is only appropriate in desktop, test, development or
       CI/CD environments.

       WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING

       Installing chef
       installing with dpkg...
       Selecting previously unselected package chef.
(Reading database ... 35394 files and directories currently installed.)
       Preparing to unpack .../chef_13.0.118-1_amd64.deb ...
       Unpacking chef (13.0.118-1) ...
       Vagrant detected both the ATLAS_TOKEN environment variable and a Vagrant login
       token are present on this system. The ATLAS_TOKEN environment variable takes
       precedence over the locally stored token. To remove this error, either unset
       the ATLAS_TOKEN environment variable or remove the login token stored on disk:

           ~/.vagrant.d/data/vagrant_login_token

       In general, the ATLAS_TOKEN is more preferred because it is respected by all
       HashiCorp products.
       Bringing machine 'default' up with 'virtualbox' provider...
       ==> default: Importing base box 'bento/ubuntu-12.04'...
       Setting up chef (13.0.118-1) ...
       Thank you for installing Chef!
       Transferring files to <default-ubuntu-1404>
       Starting Chef Client, version 13.0.118
       Creating a new client identity for default-ubuntu-1404 using the validator key.
==> default: Matching MAC address for NAT networking...
       ==> default: Checking if box 'bento/ubuntu-12.04' is up to date...
       resolving cookbooks for run list: ["newrelic-infra::default"]
       Synchronizing Cookbooks:
         - newrelic-infra (0.0.1)
       Installing Cookbook Gems:
       Compiling Cookbooks...
       Converging 7 resources
       Recipe: newrelic-infra::agent_linux
         * remote_file[/tmp/newrelic-infra.gpg] action create
           - create new file /tmp/newrelic-infra.gpg
           - update content in file /tmp/newrelic-infra.gpg from none to f776e6
           --- /tmp/newrelic-infra.gpg	2017-05-03 14:38:34.805385069 +0000
           +++ /tmp/chef-rest20170503-1627-cqlvm8	2017-05-03 14:38:34.805385069 +0000
           @@ -1 +1,31 @@
           +-----BEGIN PGP PUBLIC KEY BLOCK-----
           +Version: GnuPG v1
           +
           +mQINBFgQ8NoBEADT59GnSBJ2Pj9AMj59JNJ7davbPrqgl5zb0JO9yfw+yU+3rCUk
           +xLfdwSz8U+J7MOQ8cF3mkyIDDBfD3T1DKbAGl0Zp6cZuySSadZZJ+gMnzKiMi+5S
           +nsOxzfH2q+hJ2zPEKqWgmRIDFdKoGDFp6WRLb9ce8Crg1FJ0nx/heuRiPfilwN//
           +B6MLif3TjqSnD5Cyb1VN/b3UYHBfwvk3BPdIGC8w8VkrmeaXQQ+oIdxGAjbWuSdb
           +yd+a0uiV1vOBgz2A7P+XCwfX5qvag87z1kMNNyAJWRSrCn8j8OdHvmLc0NsZ+Hft
           +GtuieqcmD6WydaW/2rAyrlJPv+DeWV1t+YnwRLK45jstK9dCKrDMZyl/eBGnmWoa
           +L7pdgQQ4AcvEbv7F7xsWM0tlJyDgzsEhubO8Ue0r/tp51JoTXiuVAS+EcVLFCuhT
           +6XbGv/Gc/VLM613xi8WZGHumgtfFQvDrmYlVY3GBs4HPCyibJi6ZMtLYmRYzJYZJ
           +n31c5SwN9iuNEWLxySrNGJFYnJt00JcIjvrWZF44uN8U7Byzz4RQkWCBe6sEd5L2
           +TJcn/0aVQTCFn4sETzRN6GylhGuoL+eI3N0T2MRZMHKV5zBE2zwUZNV0DxqbdWWh
           +mIv/QUiYfmIaPHLHhbevXKeTbMOHQyUioKZsh0l7FyArqosMOWv8hkh9kwARAQAB
           +tDRpbmZyYXN0cnVjdHVyZS1lbmcgPGluZnJhc3RydWN0dXJlLWVuZ0BuZXdyZWxp
           +Yy5jb20+iQI4BBMBAgAiBQJYEPDaAhsvBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIX
           +gAAKCRC7Ke4DjszofMYvEACA4mZw4QGn44o9OjtoRXWry0PwxZyDb7LRFSqV/i0P
           +yBo86zth3MP4+TxduxSDdoaLxB6A2fOZX25XOTcd5ILaWgVsfcIb9SiRCBmJA9aQ
           +i5gNT/KzmCJeRyH52J+j1DPpz0JbadKxBfDLGmkeKBdIx3MCLIvchT8Wc+F+SaLT
           +8DGj6W3m5fWKeCV62OCZqu5Lq5DjU/L1AqbbgsWI3SpeFTgTy7XnOM/ecGkrjC3M
           +W+jkkhA9mU49TctWmdyFUMNQOwvdjz4BcayKZQO5ubShuYSF/J9NQnhtA9HNdLey
           +CMaru6DSUHZ2DA161joNUm7eoMyXgU6tioFBPUsNG9KIL7/9o4tR3rujCehrC1ZB
           +F3E5TySmucpueYg7C3HVjjyLDXy9hlu2DUr+8S7Sg1RT6gBHpp5BBxOrm9MxrNry
           +QM72Pw6aVPmPeaTP5RCB7orlqfYaBsrZVww22kaQB4K9jSeCaai2NIMXWEd2i3pb
           +18mFsKHrpTolzqmLvdehxtNWsE6XBJoVl0FGmtvpXwcQU/jwXvqWuOPD6Re1AvyH
           +tCrWpr7AFU0T38AXszhRdnKuqFihfWVaTlWjzqOY05xLSGBrxddAz6dJF4qCopPu
           +RxizNGC6dUJxuQlJfVLPJKN3EDSphCe/+FLa5PMt0U1NrLfuMdtZLWH5a9fbDwxw
           +TQ==
           +=uCVl
           +-----END PGP PUBLIC KEY BLOCK-----
         * execute[add apt key] action run
           - execute apt-key add /tmp/newrelic-infra.gpg
         * apt_repository[newrelic-infra] action add
           * execute[apt-cache gencaches] action nothing (skipped due to action :nothing)
           * apt_update[newrelic-infra] action nothing (skipped due to action :nothing)
           * file[/etc/apt/sources.list.d/newrelic-infra.list] action create
             - create new file /etc/apt/sources.list.d/newrelic-infra.list
             - update content in file /etc/apt/sources.list.d/newrelic-infra.list from none to e7350c
             --- /etc/apt/sources.list.d/newrelic-infra.list	2017-05-03 14:38:34.909385069 +0000
             +++ /etc/apt/sources.list.d/.chef-newrelic-infra20170503-1627-arrqei.list	2017-05-03 14:38:34.909385069 +0000
             @@ -1 +1,2 @@
             +deb      [arch=amd64] "https://download.newrelic.com/infrastructure_agent/linux/apt" trusty main
             - change mode from '' to '0644'
             - change owner from '' to 'root'
             - change group from '' to 'root'
       ==> default: Setting the name of the VM: kitchen-infrastructure-agent-chef-fork-default-ubuntu-1204_default_1493822315727_72321
       ==> default: Fixed port collision for 22 => 2222. Now on port 2201.
       ==> default: Clearing any previously set network interfaces...
       ==> default: Preparing network interfaces based on configuration...
           default: Adapter 1: nat
       ==> default: Forwarding ports...
           default: 22 (guest) => 2201 (host) (adapter 1)
       ==> default: Running 'pre-boot' VM customizations...
       ==> default: Booting VM...
       ==> default: Waiting for machine to boot. This may take a few minutes...
           * execute[apt-cache gencaches] action run
             - execute apt-cache gencaches
           * apt_update[newrelic-infra] action update
             - force update new lists of packages
             * directory[/var/lib/apt/periodic] action create (up to date)
             * directory[/etc/apt/apt.conf.d] action create (up to date)
             * file[/etc/apt/apt.conf.d/15update-stamp] action create_if_missing (up to date)
           default: SSH address: 127.0.0.1:2201
           default: SSH username: vagrant
           default: SSH auth method: private key
             * execute[apt-get -q update] action run
        - execute apt-get -q update


           default:
           default: Vagrant insecure key detected. Vagrant will automatically replace
           default: this with a newly generated keypair for better security.
           default:
           default: Inserting generated public key within guest...
           default: Removing insecure key from the guest if it's present...
           default: Key inserted! Disconnecting and reconnecting using new SSH key...
       ==> default: Machine booted and ready!
       ==> default: Checking for guest additions in VM...
       ==> default: Setting hostname...
       ==> default: Mounting shared folders...
           default: /tmp/omnibus/cache => /Users/brandon/.kitchen/cache
         * execute[apt-get update] action run
           - execute apt-get update
       ==> default: Machine not provisioned because `--no-provision` is specified.
       [SSH] Established
       Vagrant instance <default-ubuntu-1204> created.
       Finished creating <default-ubuntu-1204> (2m19.51s).
-----> Converging <default-ubuntu-1204>...
       Preparing files for transfer
       Preparing dna.json
       Resolving cookbook dependencies with Berkshelf 5.2.0...
       Removing non-cookbook files before transfer
       Preparing solo.rb
-----> Installing Chef Omnibus (install only if missing)
       Downloading https://omnitruck.chef.io/install.sh to file /tmp/install.sh
       Trying wget...
       Download complete.
       ubuntu 12.04 x86_64
       Getting information for chef stable  for ubuntu...
       downloading https://omnitruck.chef.io/stable/chef/metadata?v=&p=ubuntu&pv=12.04&m=x86_64
         to file /tmp/install.sh.1797/metadata.txt
       trying wget...
       sha1	da845676ff2e17b3049ca6e52541389318183f89
       sha256	650e80ad44584ca48716752d411989ab155845af4af7a50c530155d9718843eb
       url	https://packages.chef.io/files/stable/chef/13.0.118/ubuntu/12.04/chef_13.0.118-1_amd64.deb
       version	13.0.118
       downloaded metadata file looks valid...
       /tmp/omnibus/cache/chef_13.0.118-1_amd64.deb already exists, verifiying checksum...
       Comparing checksum with sha256sum...
       checksum compare succeeded, using existing file!

       WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING

       You are installing an omnibus package without a version pin.  If you are installing
       on production servers via an automated process this is DANGEROUS and you will
       be upgraded without warning on new releases, even to new major releases.
       Letting the version float is only appropriate in desktop, test, development or
       CI/CD environments.

       WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING

       Installing chef
       installing with dpkg...
       Selecting previously unselected package chef.
(Reading database ... 28752 files and directories currently installed.)
       Unpacking chef (from .../chef_13.0.118-1_amd64.deb) ...
       Bringing machine 'default' up with 'virtualbox' provider...
       ==> default: Box 'bento/centos-7.2' could not be found. Attempting to find and install...
           default: Box Provider: virtualbox
           default: Box Version: >= 0
       Vagrant detected both the ATLAS_TOKEN environment variable and a Vagrant login
       token are present on this system. The ATLAS_TOKEN environment variable takes
       precedence over the locally stored token. To remove this error, either unset
       the ATLAS_TOKEN environment variable or remove the login token stored on disk:

           ~/.vagrant.d/data/vagrant_login_token

       In general, the ATLAS_TOKEN is more preferred because it is respected by all
       HashiCorp products.
       ==> default: Loading metadata for box 'bento/centos-7.2'
           default: URL: https://atlas.hashicorp.com/bento/centos-7.2
       Vagrant detected both the ATLAS_TOKEN environment variable and a Vagrant login
       token are present on this system. The ATLAS_TOKEN environment variable takes
       precedence over the locally stored token. To remove this error, either unset
       the ATLAS_TOKEN environment variable or remove the login token stored on disk:

           ~/.vagrant.d/data/vagrant_login_token

       In general, the ATLAS_TOKEN is more preferred because it is respected by all
       HashiCorp products.
       ==> default: Adding box 'bento/centos-7.2' (v2.3.1) for provider: virtualbox
           default: Downloading: https://atlas.hashicorp.com/bento/boxes/centos-7.2/versions/2.3.1/providers/virtualbox.box
         * apt_package[newrelic-infra] action install
           - install version 1.0.682 of package newrelic-infra
         * service[newrelic-infra] action enable (up to date)
         * service[newrelic-infra] action start
           - start service service[newrelic-infra]
         * template[/etc/newrelic-infra.yml] action create
           - create new file /etc/newrelic-infra.yml
           - update content in file /etc/newrelic-infra.yml from none to ed63eb
           --- /etc/newrelic-infra.yml	2017-05-03 14:39:02.413574841 +0000
           +++ /etc/.chef-newrelic-infra20170503-1627-8u7z3.yml	2017-05-03 14:39:02.409574841 +0000
           @@ -1 +1,2 @@
           +license_key: REDACTED
           - change mode from '' to '0644'
           - change owner from '' to 'root'
           - change group from '' to 'root'
         * service[newrelic-infra] action restart
           - restart service service[newrelic-infra]

       Running handlers:
       Running handlers complete
       Chef Client finished, 12/18 resources updated in 30 seconds
       Finished converging <default-ubuntu-1404> (0m38.84s).
-----> Setting up <default-ubuntu-1404>...
       Finished setting up <default-ubuntu-1404> (0m0.00s).
-----> Verifying <default-ubuntu-1404>...
       Preparing files for transfer
       Transferring files to <default-ubuntu-1404>
       Finished verifying <default-ubuntu-1404> (0m0.00s).
-----> Destroying <default-ubuntu-1404>...
       Setting up chef (13.0.118-1) ...
       Thank you for installing Chef!
       Transferring files to <default-ubuntu-1204>
       Starting Chef Client, version 13.0.118
       Creating a new client identity for default-ubuntu-1204 using the validator key.
       resolving cookbooks for run list: ["newrelic-infra::default"]
       Synchronizing Cookbooks:
         - newrelic-infra (0.0.1)
       Installing Cookbook Gems:
       Compiling Cookbooks...
       Converging 7 resources
       Recipe: newrelic-infra::agent_linux
         * remote_file[/tmp/newrelic-infra.gpg] action create
           - create new file /tmp/newrelic-infra.gpg
           - update content in file /tmp/newrelic-infra.gpg from none to f776e6
           --- /tmp/newrelic-infra.gpg	2017-05-03 14:39:08.166177018 +0000
           +++ /tmp/chef-rest20170503-1882-1kujsyb	2017-05-03 14:39:08.162176999 +0000
           @@ -1 +1,31 @@
           +-----BEGIN PGP PUBLIC KEY BLOCK-----
           +Version: GnuPG v1
           +
           +mQINBFgQ8NoBEADT59GnSBJ2Pj9AMj59JNJ7davbPrqgl5zb0JO9yfw+yU+3rCUk
           +xLfdwSz8U+J7MOQ8cF3mkyIDDBfD3T1DKbAGl0Zp6cZuySSadZZJ+gMnzKiMi+5S
           +nsOxzfH2q+hJ2zPEKqWgmRIDFdKoGDFp6WRLb9ce8Crg1FJ0nx/heuRiPfilwN//
           +B6MLif3TjqSnD5Cyb1VN/b3UYHBfwvk3BPdIGC8w8VkrmeaXQQ+oIdxGAjbWuSdb
           +yd+a0uiV1vOBgz2A7P+XCwfX5qvag87z1kMNNyAJWRSrCn8j8OdHvmLc0NsZ+Hft
           +GtuieqcmD6WydaW/2rAyrlJPv+DeWV1t+YnwRLK45jstK9dCKrDMZyl/eBGnmWoa
           +L7pdgQQ4AcvEbv7F7xsWM0tlJyDgzsEhubO8Ue0r/tp51JoTXiuVAS+EcVLFCuhT
           +6XbGv/Gc/VLM613xi8WZGHumgtfFQvDrmYlVY3GBs4HPCyibJi6ZMtLYmRYzJYZJ
           +n31c5SwN9iuNEWLxySrNGJFYnJt00JcIjvrWZF44uN8U7Byzz4RQkWCBe6sEd5L2
           +TJcn/0aVQTCFn4sETzRN6GylhGuoL+eI3N0T2MRZMHKV5zBE2zwUZNV0DxqbdWWh
           +mIv/QUiYfmIaPHLHhbevXKeTbMOHQyUioKZsh0l7FyArqosMOWv8hkh9kwARAQAB
           +tDRpbmZyYXN0cnVjdHVyZS1lbmcgPGluZnJhc3RydWN0dXJlLWVuZ0BuZXdyZWxp
           +Yy5jb20+iQI4BBMBAgAiBQJYEPDaAhsvBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIX
           +gAAKCRC7Ke4DjszofMYvEACA4mZw4QGn44o9OjtoRXWry0PwxZyDb7LRFSqV/i0P
           +yBo86zth3MP4+TxduxSDdoaLxB6A2fOZX25XOTcd5ILaWgVsfcIb9SiRCBmJA9aQ
           +i5gNT/KzmCJeRyH52J+j1DPpz0JbadKxBfDLGmkeKBdIx3MCLIvchT8Wc+F+SaLT
           +8DGj6W3m5fWKeCV62OCZqu5Lq5DjU/L1AqbbgsWI3SpeFTgTy7XnOM/ecGkrjC3M
           +W+jkkhA9mU49TctWmdyFUMNQOwvdjz4BcayKZQO5ubShuYSF/J9NQnhtA9HNdLey
           +CMaru6DSUHZ2DA161joNUm7eoMyXgU6tioFBPUsNG9KIL7/9o4tR3rujCehrC1ZB
           +F3E5TySmucpueYg7C3HVjjyLDXy9hlu2DUr+8S7Sg1RT6gBHpp5BBxOrm9MxrNry
           +QM72Pw6aVPmPeaTP5RCB7orlqfYaBsrZVww22kaQB4K9jSeCaai2NIMXWEd2i3pb
           +18mFsKHrpTolzqmLvdehxtNWsE6XBJoVl0FGmtvpXwcQU/jwXvqWuOPD6Re1AvyH
           +tCrWpr7AFU0T38AXszhRdnKuqFihfWVaTlWjzqOY05xLSGBrxddAz6dJF4qCopPu
           +RxizNGC6dUJxuQlJfVLPJKN3EDSphCe/+FLa5PMt0U1NrLfuMdtZLWH5a9fbDwxw
           +TQ==
           +=uCVl
           +-----END PGP PUBLIC KEY BLOCK-----
         * execute[add apt key] action run
           - execute apt-key add /tmp/newrelic-infra.gpg
         * apt_repository[newrelic-infra] action add
           * execute[apt-cache gencaches] action nothing (skipped due to action :nothing)
           * apt_update[newrelic-infra] action nothing (skipped due to action :nothing)
           * file[/etc/apt/sources.list.d/newrelic-infra.list] action create
             - create new file /etc/apt/sources.list.d/newrelic-infra.list
             - update content in file /etc/apt/sources.list.d/newrelic-infra.list from none to 45251e
             --- /etc/apt/sources.list.d/newrelic-infra.list	2017-05-03 14:39:08.266177212 +0000
             +++ /etc/apt/sources.list.d/.chef-newrelic-infra20170503-1882-ecw9ce.list	2017-05-03 14:39:08.266177212 +0000
             @@ -1 +1,2 @@
             +deb      [arch=amd64] "https://download.newrelic.com/infrastructure_agent/linux/apt" precise main
             - change mode from '' to '0644'
             - change owner from '' to 'root'
             - change group from '' to 'root'
           * execute[apt-cache gencaches] action run
             - execute apt-cache gencaches
           * apt_update[newrelic-infra] action update
             - force update new lists of packages
             * directory[/var/lib/apt/periodic] action create (up to date)
             * directory[/etc/apt/apt.conf.d] action create (up to date)
             * file[/etc/apt/apt.conf.d/15update-stamp] action create_if_missing (up to date)
             * execute[apt-get -q update] action run
        - execute apt-get -q update


         * execute[apt-get update] action run
           - execute apt-get update
         * apt_package[newrelic-infra] action install
           - install version 1.0.682 of package newrelic-infra
         * service[newrelic-infra] action enable (up to date)
         * service[newrelic-infra] action start
           - start service service[newrelic-infra]
         * template[/etc/newrelic-infra.yml] action create
           - create new file /etc/newrelic-infra.yml
           - update content in file /etc/newrelic-infra.yml from none to ed63eb
           --- /etc/newrelic-infra.yml	2017-05-03 14:39:32.278177213 +0000
           +++ /etc/.chef-newrelic-infra20170503-1882-62sx09.yml	2017-05-03 14:39:32.278177213 +0000
           @@ -1 +1,2 @@
           +license_key: REDACTED
           - change mode from '' to '0644'
           - change owner from '' to 'root'
           - change group from '' to 'root'
         * service[newrelic-infra] action restart
           - restart service service[newrelic-infra]

       Running handlers:
       Running handlers complete
       Chef Client finished, 12/18 resources updated in 27 seconds
       Finished converging <default-ubuntu-1204> (0m35.01s).
-----> Setting up <default-ubuntu-1204>...
       Finished setting up <default-ubuntu-1204> (0m0.00s).
-----> Verifying <default-ubuntu-1204>...
       Preparing files for transfer
       Transferring files to <default-ubuntu-1204>
       Finished verifying <default-ubuntu-1204> (0m0.00s).
-----> Destroying <default-ubuntu-1204>...
Vagrant detected both the ATLAS_TOKEN environment variable and a Vagrant login
       token are present on this system. The ATLAS_TOKEN environment variable takes
       precedence over the locally stored token. To remove this error, either unset
       the ATLAS_TOKEN environment variable or remove the login token stored on disk:

           ~/.vagrant.d/data/vagrant_login_token

       In general, the ATLAS_TOKEN is more preferred because it is respected by all
       HashiCorp products.
       ==> default: Successfully added box 'bento/centos-7.2' (v2.3.1) for 'virtualbox'!
       Vagrant detected both the ATLAS_TOKEN environment variable and a Vagrant login
       token are present on this system. The ATLAS_TOKEN environment variable takes
       precedence over the locally stored token. To remove this error, either unset
       the ATLAS_TOKEN environment variable or remove the login token stored on disk:

           ~/.vagrant.d/data/vagrant_login_token

       In general, the ATLAS_TOKEN is more preferred because it is respected by all
       HashiCorp products.
       ==> default: Importing base box 'bento/centos-7.2'...
==> default: Matching MAC address for NAT networking...
       ==> default: Checking if box 'bento/centos-7.2' is up to date...
       ==> default: Setting the name of the VM: kitchen-infrastructure-agent-chef-fork-default-centos-72_default_1493822398568_21182
       ==> default: Fixed port collision for 22 => 2222. Now on port 2202.
       ==> default: Clearing any previously set network interfaces...
       ==> default: Preparing network interfaces based on configuration...
           default: Adapter 1: nat
       ==> default: Forwarding ports...
           default: 22 (guest) => 2202 (host) (adapter 1)
       ==> default: Running 'pre-boot' VM customizations...
       ==> default: Booting VM...
       ==> default: Waiting for machine to boot. This may take a few minutes...
           default: SSH address: 127.0.0.1:2202
           default: SSH username: vagrant
           default: SSH auth method: private key
           default: Warning: Remote connection disconnect. Retrying...
           default: Warning: Connection reset. Retrying...
           default: Warning: Remote connection disconnect. Retrying...
           default: Warning: Connection reset. Retrying...
           default: Warning: Remote connection disconnect. Retrying...
           default: Warning: Connection reset. Retrying...
           default: Warning: Remote connection disconnect. Retrying...
           default: Warning: Connection reset. Retrying...
           default: Warning: Remote connection disconnect. Retrying...
           default:
           default: Vagrant insecure key detected. Vagrant will automatically replace
           default: this with a newly generated keypair for better security.
           default:
           default: Inserting generated public key within guest...
           default: Removing insecure key from the guest if it's present...
           default: Key inserted! Disconnecting and reconnecting using new SSH key...
       ==> default: Machine booted and ready!
       ==> default: Checking for guest additions in VM...
       ==> default: Setting hostname...
       ==> default: Mounting shared folders...
           default: /tmp/omnibus/cache => /Users/brandon/.kitchen/cache
       ==> default: Machine not provisioned because `--no-provision` is specified.
       [SSH] Established
       Vagrant instance <default-centos-72> created.
       Finished creating <default-centos-72> (3m54.93s).
-----> Converging <default-centos-72>...
       Preparing files for transfer
       Preparing dna.json
       Resolving cookbook dependencies with Berkshelf 5.2.0...
       Removing non-cookbook files before transfer
       Preparing solo.rb
-----> Installing Chef Omnibus (install only if missing)
       Downloading https://omnitruck.chef.io/install.sh to file /tmp/install.sh
       Trying wget...
       Download complete.
       el 7 x86_64
       Getting information for chef stable  for el...
       downloading https://omnitruck.chef.io/stable/chef/metadata?v=&p=el&pv=7&m=x86_64
         to file /tmp/install.sh.10149/metadata.txt
       trying wget...
       sha1	f0eac57e53833d710334839fbe4e9b940d1c43c6
       sha256	a3cb30fe2eb6e3ce5ea8914635d01562660f4978568fa3303b14336eefdb09ee
       url	https://packages.chef.io/files/stable/chef/13.0.118/el/7/chef-13.0.118-1.el7.x86_64.rpm
       version	13.0.118
       downloaded metadata file looks valid...
       downloading https://packages.chef.io/files/stable/chef/13.0.118/el/7/chef-13.0.118-1.el7.x86_64.rpm
         to file /tmp/omnibus/cache/chef-13.0.118-1.el7.x86_64.rpm
       trying wget...
       Vagrant detected both the ATLAS_TOKEN environment variable and a Vagrant login
       token are present on this system. The ATLAS_TOKEN environment variable takes
       precedence over the locally stored token. To remove this error, either unset
       the ATLAS_TOKEN environment variable or remove the login token stored on disk:

           ~/.vagrant.d/data/vagrant_login_token

       In general, the ATLAS_TOKEN is more preferred because it is respected by all
       HashiCorp products.
       Comparing checksum with sha256sum...

       WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING

       You are installing an omnibus package without a version pin.  If you are installing
       on production servers via an automated process this is DANGEROUS and you will
       be upgraded without warning on new releases, even to new major releases.
       Letting the version float is only appropriate in desktop, test, development or
       CI/CD environments.

       WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING

       Installing chef
       installing with rpm...
       ==> default: Forcing shutdown of VM...
       warning: /tmp/omnibus/cache/chef-13.0.118-1.el7.x86_64.rpm: Header V4 DSA/SHA1 Signature, key ID 83ef826a: NOKEY
       Preparing...                          ################################# [100%]
       Updating / installing...
       ==> default: Destroying VM and associated drives...
       Vagrant instance <default-centos-68> destroyed.
       Finished destroying <default-centos-68> (2m40.71s).
       Finished testing <default-centos-68> (3m59.99s).
       Vagrant detected both the ATLAS_TOKEN environment variable and a Vagrant login
       token are present on this system. The ATLAS_TOKEN environment variable takes
       precedence over the locally stored token. To remove this error, either unset
       the ATLAS_TOKEN environment variable or remove the login token stored on disk:

           ~/.vagrant.d/data/vagrant_login_token

       In general, the ATLAS_TOKEN is more preferred because it is respected by all
       HashiCorp products.
       ==> default: Forcing shutdown of VM...
       ==> default: Destroying VM and associated drives...
       Vagrant instance <default-ubuntu-1404> destroyed.
       Finished destroying <default-ubuntu-1404> (1m40.70s).
       Finished testing <default-ubuntu-1404> (4m5.41s).
          1:chef-13.0.118-1.el7              ################################# [100%]
       Thank you for installing Chef!
       Transferring files to <default-centos-72>
       Vagrant detected both the ATLAS_TOKEN environment variable and a Vagrant login
       token are present on this system. The ATLAS_TOKEN environment variable takes
       precedence over the locally stored token. To remove this error, either unset
       the ATLAS_TOKEN environment variable or remove the login token stored on disk:

           ~/.vagrant.d/data/vagrant_login_token

       In general, the ATLAS_TOKEN is more preferred because it is respected by all
       HashiCorp products.
       Starting Chef Client, version 13.0.118
       ==> default: Forcing shutdown of VM...
       Creating a new client identity for default-centos-72 using the validator key.
       resolving cookbooks for run list: ["newrelic-infra::default"]
       Synchronizing Cookbooks:
         - newrelic-infra (0.0.1)
       Installing Cookbook Gems:
       Compiling Cookbooks...
       Converging 5 resources
       Recipe: newrelic-infra::agent_linux
         * yum_repository[newrelic-infra] action create
           * template[/etc/yum.repos.d/newrelic-infra.repo] action create
             - create new file /etc/yum.repos.d/newrelic-infra.repo
             - update content in file /etc/yum.repos.d/newrelic-infra.repo from none to ec6143
             --- /etc/yum.repos.d/newrelic-infra.repo	2017-05-03 14:40:47.673278499 +0000
             +++ /etc/yum.repos.d/.chef-newrelic-infra20170503-11628-1hn7pdi.repo	2017-05-03 14:40:47.673278499 +0000
             @@ -1 +1,12 @@
             +# This file was generated by Chef
             +# Do NOT modify this file by hand.
             +
             +[newrelic-infra]
             +name=New Relic Infrastructure
             +baseurl=https://download.newrelic.com/infrastructure_agent/linux/yum/el/7/x86_64
             +enabled=1
             +fastestmirror_enabled=0
             +gpgcheck=1
             +gpgkey=https://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg
             +repo_gpgcheck=1
             - change mode from '' to '0644'
             - restore selinux security context
       ==> default: Destroying VM and associated drives...
           * execute[yum clean metadata newrelic-infra] action run
             - execute yum clean metadata --disablerepo=* --enablerepo=newrelic-infra
       Vagrant instance <default-ubuntu-1204> destroyed.
       Finished destroying <default-ubuntu-1204> (1m15.80s).
       Finished testing <default-ubuntu-1204> (4m10.34s).
           * execute[yum-makecache-newrelic-infra] action run
             - execute yum -q -y makecache --disablerepo=* --enablerepo=newrelic-infra
           * ruby_block[yum-cache-reload-newrelic-infra] action create
             - execute the ruby block yum-cache-reload-newrelic-infra
           * execute[yum clean metadata newrelic-infra] action nothing (skipped due to action :nothing)
           * execute[yum-makecache-newrelic-infra] action nothing (skipped due to action :nothing)
           * ruby_block[yum-cache-reload-newrelic-infra] action nothing (skipped due to action :nothing)

         * execute[Update Infra Yum repo] action run
           - execute yum -q makecache -y --disablerepo='*' --enablerepo='newrelic-infra'
         * yum_package[newrelic-infra] action install
           - install version 1.0.682-1 of package newrelic-infra
         * service[newrelic-infra] action enable (up to date)
         * service[newrelic-infra] action start


    1 # Contributing
           - start service service[newrelic-infra]
         * template[/etc/newrelic-infra.yml] action create
           - create new file /etc/newrelic-infra.yml
           - update content in file /etc/newrelic-infra.yml from none to ed63eb
           --- /etc/newrelic-infra.yml	2017-05-03 14:41:23.369117500 +0000
           +++ /etc/.chef-newrelic-infra20170503-11628-ehmmol.yml	2017-05-03 14:41:23.368117000 +0000
           @@ -1 +1,2 @@
           +license_key: REDACTED
           - change mode from '' to '0644'
           - change owner from '' to 'root'
           - change group from '' to 'root'


  1 Add myself to CONTRIBUTING file per guidelines
           - restore selinux security context
         * service[newrelic-infra] action restart
           - restart service service[newrelic-infra]

       Running handlers:
       Running handlers complete
       Chef Client finished, 10/14 resources updated in 37 seconds
       Finished converging <default-centos-72> (0m50.58s).
-----> Setting up <default-centos-72>...
       Finished setting up <default-centos-72> (0m0.00s).
-----> Verifying <default-centos-72>...
       Preparing files for transfer
       Transferring files to <default-centos-72>
       Finished verifying <default-centos-72> (0m0.00s).
-----> Destroying <default-centos-72>...
       Vagrant detected both the ATLAS_TOKEN environment variable and a Vagrant login
       token are present on this system. The ATLAS_TOKEN environment variable takes
       precedence over the locally stored token. To remove this error, either unset
       the ATLAS_TOKEN environment variable or remove the login token stored on disk:

           ~/.vagrant.d/data/vagrant_login_token

       In general, the ATLAS_TOKEN is more preferred because it is respected by all
       HashiCorp products.
       ==> default: Forcing shutdown of VM...
       ==> default: Destroying VM and associated drives...
       Vagrant instance <default-centos-72> destroyed.
       Finished destroying <default-centos-72> (0m4.48s).
       Finished testing <default-centos-72> (4m50.02s).
-----> Kitchen is finished. (4m50.53s)
```