### PR TITLE
Add support for RedHat Linux

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,3 +19,4 @@ Copyright (c) 2017 New Relic, Inc. All rights reserved.
 
 * David Lanner (@dlanner)
 * Robert Hak <robert.hak @ iacapps.com>
+* Jordan Faust (jfaust47@gmail.com)

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ This cookbook installs and configures the New Relic Infrastructure agent.
 ### Platforms
 
 - RHEL
+  - Red Hat 6
+  - Red Hat 7
   - CentOS 7
   - CentOS 6
   - Amazon Linux (all versions)

--- a/recipes/agent.rb
+++ b/recipes/agent.rb
@@ -14,7 +14,7 @@ when 'debian'
   include_recipe 'newrelic-infra::agent_linux'
 when 'rhel'
   case node['platform']
-  when 'centos'
+  when 'centos', 'redhat'
     case node['platform_version']
     when /^6/, /^7/
       include_recipe 'newrelic-infra::agent_linux'

--- a/recipes/agent_linux.rb
+++ b/recipes/agent_linux.rb
@@ -37,7 +37,7 @@ when 'debian'
 when 'rhel'
   # Add Yum repo
   case node['platform']
-  when 'centos'
+  when 'centos', 'redhat'
     rhel_version = node['platform_version'].to_i
   when 'amazon'
     case node['platform_version'].to_i


### PR DESCRIPTION
This resolves https://github.com/newrelic/infrastructure-agent-chef/issues/5

Currently RedHat is not supported even though the agent runs on RedHat 6 and 7. This PR adds support for RedHat.