### PR TITLE
Add the ability to specify custom attributes for an agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ See `attributes/defaults.rb` for default values.
   - `'upgrade'`: Installs package and/or ensures it's the latest version.
   - `'remove'`:  Removes the package.
 - `node['newrelic-infra']['agent_version']` - Specify `newrelic-infra` package version to pin.
+- `node['newrelic-infra']['custom_attributes']` - Specify custom attributes as key/value pairs.
 
 ## Usage
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -9,3 +9,4 @@ default['newrelic-infra']['display_name'] = nil
 default['newrelic-infra']['proxy'] = nil
 default['newrelic-infra']['verbose'] = nil
 default['newrelic-infra']['log_file'] = nil
+default['newrelic-infra']['custom_attributes'] = {}

--- a/recipes/agent_linux.rb
+++ b/recipes/agent_linux.rb
@@ -93,7 +93,8 @@ template '/etc/newrelic-infra.yml' do
     'display_name' => node['newrelic-infra']['display_name'],
     'log_file' => node['newrelic-infra']['log_file'],
     'verbose' => node['newrelic-infra']['verbose'],
-    'proxy' => node['newrelic-infra']['proxy']
+    'proxy' => node['newrelic-infra']['proxy'],
+    'custom_attributes' => node['newrelic-infra']['custom_attributes']
   )
   notifies :restart, 'service[newrelic-infra]', :delayed
 end

--- a/templates/default/newrelic-infra.yml.erb
+++ b/templates/default/newrelic-infra.yml.erb
@@ -11,3 +11,9 @@ verbose: <%= @verbose %>
 <% unless @proxy.nil? || @proxy.empty? -%>
 proxy: <%= @proxy %>
 <% end -%>
+<% unless @custom_attributes.nil? || @custom_attributes.empty? -%>
+custom_attributes:
+<% @custom_attributes.each do |key, value| -%>
+  <%= "#{key}: #{value}"%>
+<% end -%>
+<% end -%>


### PR DESCRIPTION
Adding custom attributes is not currently supported in the cookbook. This PR provides a hash that consumers can use to specify custom attributes for an agent. 