### PR TITLE
Make yum repo and gpg key configurable

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -4,6 +4,11 @@
 default['newrelic-infra']['agent_action'] = 'install'
 default['newrelic-infra']['agent_version'] = nil
 
+default['newrelic-infra']['yum'] = {}
+default['newrelic-infra']['yum']['baseurl'] = nil
+default['newrelic-infra']['yum']['gpgkey'] = nil
+default['newrelic-infra']['yum']['repo_gpgcheck'] = true
+
 default['newrelic-infra']['license_key'] = nil
 default['newrelic-infra']['display_name'] = nil
 default['newrelic-infra']['proxy'] = nil

--- a/recipes/agent_linux.rb
+++ b/recipes/agent_linux.rb
@@ -46,12 +46,20 @@ when 'rhel'
     end
   end
 
+  if node['newrelic-infra']['yum']['baseurl'].nil?
+    base_url = "https://download.newrelic.com/infrastructure_agent/linux/yum/el/#{rhel_version}/x86_64"
+  end
+
+  if node['newrelic-infra']['yum']['gpgkey'].nil?
+    gpg_key = 'https://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg'
+  end
+
   yum_repository 'newrelic-infra' do
     description "New Relic Infrastructure"
-    baseurl "https://download.newrelic.com/infrastructure_agent/linux/yum/el/#{rhel_version}/x86_64"
-    gpgkey 'https://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg'
+    baseurl node['newrelic-infra']['yum']['baseurl'] || base_url
+    gpgkey node['newrelic-infra']['yum']['gpgkey'] || gpg_key
     gpgcheck true
-    repo_gpgcheck true
+    repo_gpgcheck node['newrelic-infra']['yum']['repo_gpgcheck']
   end
 
   # Update Yum repo


### PR DESCRIPTION
Its a common security practice for companies to mirror repos that they depend on. This cookbook forces the use of the public repo. This PR makes the repo and related configuration configurable so that the yum repo can be configured to pull from a private mirrored repo.