### PR TITLE
Fix integration Chef 13 requirement

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -2,6 +2,7 @@
 driver:
   name: vagrant
   provider: virtualbox
+  chef_version: <%= ENV['CHEF_VERSION'] || '12.21' %>
 
 provisioner:
   name: chef_zero

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,21 +2,33 @@
 
 This file is used to list changes made in each version of the `newrelic-infra` cookbook.
 
-## v0.1.0 (UNRELEASED)
+## v0.1.1
 
-NOTE: Versions prior to 0.1.0 were not tagged or released on the [Chef supermarket][1].
+BREAKING CHANGES:
+
+* The minimum supported Chef version is now 12.21 instead of 12.14. Older 
+  versions of 12 should work, but this version has better support in automated
+  testing environments.
+
+BUG FIXES:
+
+* Remove the use of `Hash#compact`, which only works with Ruby >= 2.4. Chef 12 does not ship with a    version this new. Replace with `Hash#reject`.
+
+## v0.1.0
+
+NOTE: Versions prior to 0.1.0 were not tagged or released on the [Chef supermarket](https://supermarket.chef.io/).
 
 BREAKING CHANGES:
 
 * *Attribute namespace changed:* The top-level attribute key was changed from `newrelic-infra` to `newrelic_infra` in order to be used as both strings and symbols.
 * Only `chef-client` versions `>= 12.14` are supported.
-* Lots of attribute changes to help simplify configuration generation. See the [README][2] for more details.
+* Lots of attribute changes to help simplify configuration generation. See the [README](README.md) for more details.
 
 FEATURES:
 
-* *Testing added:* Unit and integration tests added. See the [CONTRIBUTING][3] guide for more details.
+* *Testing added:* Unit and integration tests added. See the [CONTRIBUTING](CONTRIBUTING.md) guide for more details.
 * *newrelic\_infra\_integration LWRP added:* An LWRP for installing and configuring custom New Relic Infrastructure on-host integrations. Custom integrations can also be installed using by including the default recipe and the appropriate attributes.
-* *New Relic On-Host integrations:* Added the capability to install and configure the New Relic provided on-host integrations. See the [README][3] for more details on what attributes to set.
+* *New Relic On-Host integrations:* Added the capability to install and configure the New Relic provided on-host integrations. See the README for more details on what attributes to set.
 
 IMPROVEMENTS:
 
@@ -24,7 +36,3 @@ IMPROVEMENTS:
 * Resolved all Rubocop and Foodcritic violations.
 
 BUG FIXES:
-
-[1]:  https://supermarket.chef.io/
-[2]:  README.md
-[3]:  CONTRIBUTING.md

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ See the [CHANGELOG][11] for information on the latest changes.
 
 ### Chef
 
-- Chef 12.14+
+- Chef 12.21+
 
 ### Cookbooks
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,8 +7,8 @@ description       'Installs/Configures the New Relic Infrastructure agent ' \
 long_description  IO.read(File.join(__dir__, 'README.md'))
 source_url        'https://github.com/newrelic/infrastructure-agent-chef'
 issues_url        'https://github.com/newrelic/infrastructure-agent-chef/issues'
-version           '0.1.0'
-chef_version      '>= 12.14'
+version           '0.1.1'
+chef_version      '>= 12.21'
 
 # Platform support
 supports 'amazon', '>= 2013.0'

--- a/recipes/host_integrations.rb
+++ b/recipes/host_integrations.rb
@@ -16,7 +16,7 @@ end
 # Generate configuration for the New Relic provided host integrations
 node['newrelic_infra']['host_integrations']['config'].each do |integration_name, config|
   file ::File.join(node['newrelic_infra']['host_integrations']['config_dir'], "#{integration_name}.yaml") do
-    content(lazy { YAML.dump(config.to_hash.compact.deep_stringify) })
+    content(lazy { YAML.dump(config.to_hash.reject { |_, v| v.nil? }.deep_stringify) })
     owner node['newrelic_infra']['user']['name']
     group node['newrelic_infra']['group']['name']
     mode  '0640'


### PR DESCRIPTION
Remove the use of `Hash#compact`, which only works with Ruby >= 2.4. Chef 12 does not ship with a    version this new. Replace with `Hash#reject`.

The minimum supported Chef version is now 12.21 instead of 12.14. Older
versions of 12 should work, but this version has better support in automated testing environments. (See https://hub.docker.com/r/chef/chef/tags/)

Fixes #14