### PR TITLE
turning file resource in agent linux to sensitive

### DIFF
--- a/recipes/agent_linux.rb
+++ b/recipes/agent_linux.rb
@@ -76,6 +76,7 @@ file node['newrelic_infra']['agent']['flags']['config'] do
   owner node['newrelic_infra']['user']['name']
   group node['newrelic_infra']['group']['name']
   mode  '0640'
+  sensitive true
   notifies :restart, 'poise_service[newrelic-infra]'
 end
 


### PR DESCRIPTION
Currently in the agent_linux recipe, when the agent.yaml gets generated, it's content gets exposed in the STDOUT or wherever Chef writes its logs
turning the resource to sensitive avoids this, that way the license_key isn't exposed in chef logs