### PR TITLE
Add .kitchen.dokken.yml

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -1,0 +1,39 @@
+driver:
+  name: dokken
+  privileged: true # because Docker and SystemD/Upstart
+  chef_version: <%= ENV['CHEF_VERSION'] || 12 %>
+
+transport:
+  name: dokken
+
+provisioner:
+  name: dokken
+  deprecations_as_errors: true
+
+platforms:
+- name: centos-6
+  driver:
+    image: dokken/centos-6
+    pid_one_command: /sbin/init
+- name: centos-7
+  driver:
+    image: dokken/centos-7
+    pid_one_command: /usr/lib/systemd/systemd
+- name: ubuntu-12.04
+  driver:
+    image: dokken/ubuntu-12.04
+    pid_one_command: /sbin/init
+    intermediate_instructions:
+      - RUN /usr/bin/apt-get update
+- name: ubuntu-14.04
+  driver:
+    image: dokken/ubuntu-14.04
+    pid_one_command: /sbin/init
+    intermediate_instructions:
+      - RUN /usr/bin/apt-get update
+- name: ubuntu-16.04
+  driver:
+    image: dokken/ubuntu-16.04
+    pid_one_command: /bin/systemd
+    intermediate_instructions:
+      - RUN /usr/bin/apt-get update

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,32 +1,30 @@
----
 driver:
   name: vagrant
   provider: virtualbox
 
 provisioner:
   name: chef_zero
-  chef_version: <%= ENV['CHEF_VERSION'] || 12 %>
+  require_chef_omnibus: <%= ENV['CHEF_VERSION'] || 12 %>
 
 verifier:
   name: inspec
 
 platforms:
-# Ubuntu 12.04 LTS Precise Pangolin
+- name: centos-6
+  driver:
+    box: bento/centos-6
+- name: centos-7
+  driver:
+    box: bento/centos-7
 - name: ubuntu-12.04
   driver:
     box: bento/ubuntu-12.04
-# Ubuntu 14.04 LTS Trusty Tahr
 - name: ubuntu-14.04
   driver:
     box: bento/ubuntu-14.04
-# CentOS 6.8
-- name: centos-6.8
+- name: ubuntu-16.04
   driver:
-    box: bento/centos-6.8
-# CentOS 7.2
-- name: centos-7.2
-  driver:
-    box: bento/centos-7.2
+    box: bento/ubuntu-16.04
 
 suites:
 - name: default

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,6 +114,8 @@ Tests should be designed to ensure that a recipe has accomplished its respective
 All integration tests have been written using [Inspec][10].
 See [.kitchen.yaml][11] for more information on the specific configuration.
 
+To run tests using [Docker][21] and [kitchen-docken][22] set the `KITCHEN_LOCAL_YAML` environment variable to `.kitchen.dokken.yml`.
+
 Platforms tested:
 
 * [ubuntu-12.04][15]
@@ -171,3 +173,5 @@ Copyright (c) 2016-2017 New Relic, Inc. All rights reserved.
 [18]:  https://app.vagrantup.com/bento/boxes/centos-7.2
 [19]:  https://downloads.chef.io/chef-dk/
 [20]:  https://github.com/chef-cookbooks/community_cookbook_tools/blob/master/delivery/project.toml
+[21]:  https://www.docker.com/
+[22]:  https://github.com/someara/kitchen-dokken

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ An error will be raised and fail the `chef-client` run for any detected Windows 
 Installs New Relic provided and custom on-host integrations if the associated feature flag is enabled (i.e., `default['newrelic_infra']['features]['host_integrations']`).
 Generates configuration for any of the available on-host integrations from New Relic.
 Installs any custom integrations defined with attributes.
-For more infromation on the available LWRP for installing and configuring custom on-host integrations see the [LWRPs][9] documentation.
+For more infromation on the available custom resource for installing and configuring custom on-host integrations see the [Custom resources][9] documentation.
 
 Example configuration for a custom on-host integration installed and configured via attributes:
 
@@ -159,7 +159,7 @@ For more information, refer to the Chef documentation on the [yum_repository][5]
 | `default['newrelic_infra']['yum']['repo_gpgcheck']` | `true` | Perform a GPG check on the package repository |
 | `default['newrelic_infra']['yum']['action']` | `[:add, :makecache]` | `yum_repository` resource actions to perform |
 
-## LWRPs
+## Custom Resources
 
 ### `newrelic_infra_integration`
 
@@ -221,10 +221,10 @@ Supported properties:
 - Add the `newrelic-infra::default` recipe your run list
 - For wrapper cookbooks, add the `newrelic-infra` cookbook as a dependency to your `metadata.rb` or `Berksfile`, then include `newrelic-infra::default` recipe.
 
-### LWRP usage
+### Custom resource usage
 
 - Add the `newrelic-infra` cookbook as a dependency to your `metadata.rb` or `Berksfile`
-- Configure the LWRP(s) using the supported properties
+- Configure the custom resource(s) using the supported properties
 
 ## Testing
 
@@ -240,6 +240,6 @@ Copyright (c) 2016-2017 New Relic, Inc. All rights reserved.
 [6]:  https://docs.newrelic.com/docs/infrastructure/integrations/cassandra-integration-new-relic-infrastructure
 [7]:  https://docs.newrelic.com/docs/infrastructure/integrations/mysql-integration-new-relic-infrastructure
 [8]:  https://docs.newrelic.com/docs/infrastructure/integrations/nginx-integration-new-relic-infrastructure
-[9]:  #lwrps
+[9]:  #custom-resources
 [10]:  CONTRIBUTING.md
 [11]:  CHANGELOG.md

--- a/libraries/integration.rb
+++ b/libraries/integration.rb
@@ -1,5 +1,5 @@
 module NewRelicInfraCookbook
-  # Chef LWRP to install the New Relic infrastructure agent on a node.
+  # Chef custom resource to install the New Relic infrastructure agent on a node.
   class Integration < ::Chef::Resource
     BASENAME_IGNORE = /(\.(t?(ar|gz|bz2?|xz)|zip))+$/
 

--- a/recipes/agent_linux.rb
+++ b/recipes/agent_linux.rb
@@ -6,7 +6,7 @@
 
 #
 # Recipe to install and configure the New Relic Infrastructure agent on Linux
-# TODO: Convert to LWRP
+# TODO: Convert to custom resource
 #
 node.default['newrelic_infra']['agent']['flags']['config'] = ::File.join(
   node['newrelic_infra']['agent']['directory']['path'],


### PR DESCRIPTION
Allows running Test Kitchen in Docker.

Also replace "LWRP" with "Custom resource" in docs and comments.

Use `require_chef_omnibus` instead of `chef_version` in Vagrant provisioner settings.