### PR TITLE
Add retries to package installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,9 +109,11 @@ See [attributes/defaults.rb][3] for more details and default values.
 | `default['newrelic_infra']['agent']['directory']['path']` | `/etc/newrelic-infra` | Directory path for the agent configuration |
 | `default['newrelic_infra']['agent']['directory']['mode']` | `0750` | Directory permissions for the agent configuration |
 | `default['newrelic_infra']['packages']['agent']['action']` | `[:install]` | Action(s) to perform on the agent package |
-| `default['newrelic_infra']['packages']['agent']['version']` | `nil` | Verion of the agent package to install |
+| `default['newrelic_infra']['packages']['agent']['retries']` | `0` | The number of times to catch exceptions and retry the resource |
+| `default['newrelic_infra']['packages']['agent']['version']` | `nil` | Version of the agent package to install |
 | `default['newrelic_infra']['packages']['host_integrations']['action']` | `[:install]` | Action(s) to perform on the agent on-host integrations package |
-| `default['newrelic_infra']['packages']['host_integrations']['version']` | `nil` | Verion of the on-host integrations package to install |
+| `default['newrelic_infra']['packages']['host_integrations']['retries']` | `0` | The number of times to catch exceptions and retry the resource |
+| `default['newrelic_infra']['packages']['host_integrations']['version']` | `nil` | Version of the on-host integrations package to install |
 | `default['newrelic_infra']['host_integrations']['config_dir']` | `/etc/newrelic-infra/integrations.d` | Directory for the New Relic provided on-host integration configurations |
 | `default['newrelic_infra']['host_integrations']['config']` | `{}` | New Relic provided on-host integration configuration |
 | `default['newrelic_infra']['custom_integrations']` | `{}` | New Relic Infrastructure on-host custom integration configuration |

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -44,11 +44,13 @@ end
 
 # New Relic Infrastructure agent package configuration
 default['newrelic_infra']['packages']['agent']['action'] = %i(install)
+default['newrelic_infra']['packages']['agent']['retries'] = 0
 default['newrelic_infra']['packages']['agent']['version'] = nil
 
 # New Relic Infrastructure on-host integration package configuration
 # NOTE: The package actions only be performed if the associated feature flag is enabled.
 default['newrelic_infra']['packages']['host_integrations']['action'] = %i(install)
+default['newrelic_infra']['packages']['host_integrations']['retries'] = 0
 default['newrelic_infra']['packages']['host_integrations']['version'] = nil
 
 # New Relic Infrastructure on-host integration configuration

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ description       'Installs/Configures the New Relic Infrastructure agent ' \
 long_description  IO.read(File.join(__dir__, 'README.md'))
 source_url        'https://github.com/newrelic/infrastructure-agent-chef'
 issues_url        'https://github.com/newrelic/infrastructure-agent-chef/issues'
-version           '0.4.0'
+version           '0.5.0'
 chef_version      '>= 12.15'
 
 # Platform support

--- a/recipes/agent_linux.rb
+++ b/recipes/agent_linux.rb
@@ -56,6 +56,7 @@ end
 # Install the newrelic-infra agent
 package 'newrelic-infra' do
   action node['newrelic_infra']['packages']['agent']['action']
+  retries node['newrelic_infra']['packages']['agent']['retries']
   version node['newrelic_infra']['packages']['agent']['version'].to_s
 end
 

--- a/recipes/agent_windows.rb
+++ b/recipes/agent_windows.rb
@@ -19,6 +19,7 @@ windows_package 'newrelic-infra' do
   action :install
   checksum node['newrelic-infra']['windows_checksum']
   installer_type :msi
+  retries node['newrelic_infra']['packages']['agent']['retries']
   source node['newrelic-infra']['windows_source']
 end
 

--- a/recipes/host_integrations.rb
+++ b/recipes/host_integrations.rb
@@ -10,6 +10,7 @@
 if node['newrelic_infra']['features']['host_integrations']
   package 'newrelic-infra-integrations' do
     action node['newrelic_infra']['packages']['host_integrations']['action']
+    retries node['newrelic_infra']['packages']['host_integrations']['retries']
     version node['newrelic_infra']['packages']['host_integrations']['version'].to_s
   end
 

--- a/spec/agent_linux_spec.rb
+++ b/spec/agent_linux_spec.rb
@@ -55,7 +55,9 @@ describe 'newrelic-infra::agent_linux' do
     end
 
     it 'should install the agent package' do
-      expect(chef_cached).to install_package('newrelic-infra')
+      expect(chef_cached).to install_package('newrelic-infra').with(action: [:install],
+                                                                    retries: 3,
+                                                                    version: '')
     end
 
     it 'should enable the agent service' do
@@ -74,7 +76,9 @@ describe 'newrelic-infra::agent_linux' do
       context "On #{platform}: #{version} with default attributes" do
         let(:chef_run) do
           ChefSpec::SoloRunner.new(platform: platform.to_s,
-                                   version: version).converge(described_recipe)
+                                   version: version) do |node|
+                                     node.normal['newrelic_infra']['packages']['agent']['retries'] = 3
+                                   end.converge(described_recipe)
         end
         cached(:chef_cached) { chef_run }
 

--- a/spec/agent_windows_spec.rb
+++ b/spec/agent_windows_spec.rb
@@ -8,10 +8,18 @@ require 'spec_helper'
 
 describe 'newrelic-infra::agent_windows' do
   let(:chef_run) do
-    ChefSpec::SoloRunner.new(platform: 'windows', version: '2016').converge(described_recipe)
+    ChefSpec::SoloRunner.new(platform: 'windows', version: '2016') do |node|
+      node.normal['newrelic_infra']['packages']['agent']['retries'] = 3
+    end.converge(described_recipe)
   end
 
   it 'converges' do
     expect { chef_run }.to_not raise_error
+  end
+
+  it 'installs the agent package' do
+    expect(chef_run).to install_windows_package('newrelic-infra').with(action: [:install],
+                                                                       retries: 3,
+                                                                       version: nil)
   end
 end

--- a/spec/host_integrations_spec.rb
+++ b/spec/host_integrations_spec.rb
@@ -11,7 +11,9 @@ describe 'newrelic-infra::host_integrations' do
     let(:file_path) { '/etc/newrelic-infra/integrations.d/cassandra.yaml' }
 
     it 'should install the agent package' do
-      expect(chef_cached).to install_package('newrelic-infra-integrations')
+      expect(chef_cached).to install_package('newrelic-infra-integrations').with(action: [:install],
+                                                                                 retries: 3,
+                                                                                 version: '')
     end
 
     it 'should create the on-host integration configuration directory' do
@@ -47,6 +49,7 @@ describe 'newrelic-infra::host_integrations' do
             node.normal['newrelic_infra']['features']['host_integrations'] = true
             node.normal['newrelic_infra']['host_integrations']['config']['cassandra']['username'] = 'chef'
             node.normal['newrelic_infra']['host_integrations']['config']['cassandra']['password'] = 'spec'
+            node.normal['newrelic_infra']['packages']['host_integrations']['retries'] = 3
           end
         end
         let(:chef_run) do


### PR DESCRIPTION
The additional attributes let you specify the times to retry installation of packages. Defaults to 0.

Fixes #28.