### PR TITLE
pattern-match on later versions of 2013 aws os

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -80,7 +80,8 @@ default['newrelic_infra']['yum'].tap do |conf|
   conf['description'] = 'New Relic Infrastructure'
   conf['baseurl'] = value_for_platform(
     amazon: {
-      '>= 2013' => 'https://download.newrelic.com/infrastructure_agent/linux/yum/el/6/x86_64',
+      '= 2013' => 'https://download.newrelic.com/infrastructure_agent/linux/yum/el/6/x86_64',
+      '> 2013.0' => 'https://download.newrelic.com/infrastructure_agent/linux/yum/el/6/x86_64',
     },
     %w(redhat oracle centos) => {
       default: "https://download.newrelic.com/infrastructure_agent/linux/yum/el/#{node['platform_version'].to_i}/x86_64",


### PR DESCRIPTION
Using chef `12.5.1`, on platform-family `amazon`, platform version `2017.03`, attributes doesn't provide a match for me.

This patch attempts to fix that by adding another matching clause.