### PR TITLE
Added SLES support

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -1,7 +1,7 @@
 driver:
   name: dokken
   privileged: true # because Docker and SystemD/Upstart
-  chef_version: <%= ENV['CHEF_VERSION'] || 12 %>
+  chef_version: <%= ENV['CHEF_VERSION'] || 13 %>
 
 transport:
   name: dokken
@@ -37,3 +37,9 @@ platforms:
     pid_one_command: /bin/systemd
     intermediate_instructions:
       - RUN /usr/bin/apt-get update
+- name: opensuse-leap
+  driver:
+    image: dokken/opensuse-leap
+    pid_one_command: /bin/systemd
+    intermediate_instructions:
+      - RUN /usr/bin/zypper ref

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ env:
   - INSTANCE=default-centos-7
   - INSTANCE=default-ubuntu-1404
   - INSTANCE=default-ubuntu-1604
+  - INSTANCE=default-opensuse-leap
   - INSTANCE=verify
 install: skip # Don't `bundle install` which takes about 1.5 mins
 jobs:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -167,6 +167,7 @@ To create a release:
 * Mark Whelan (mbwhelan@gmail.com)
 * [Trevor Wood][1] ([trevor.g.wood@gmail.com][2])
 * Codarren Velvindron (codarren@hackers.mu)
+* Ruben Hervas (@xino12)
 
 Copyright (c) 2016-2017 New Relic, Inc. All rights reserved.
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -92,3 +92,17 @@ default['newrelic_infra']['yum'].tap do |conf|
   conf['repo_gpgcheck'] = true
   conf['action'] = %i(add makecache)
 end
+
+# Zypp repository configuration for SLES based hosts
+# See https://docs.chef.io/resource_zypper_repository.html for more information
+default['newrelic_infra']['zypper'].tap do |conf|
+  conf['description'] = 'New Relic Infrastructure'
+  # TODO: Create a dokken image for SLES 12.4
+  conf['baseurl'] = 'https://download.newrelic.com/infrastructure_agent/beta/linux/zypp/sles/12.4/x86_64'
+  # conf['baseurl'] = "https://download.newrelic.com/infrastructure_agent/beta/linux/zypp/sles/#{node['platform_version'].to_i}/x86_64"
+  conf['gpgkey'] = 'https://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg'
+  conf['gpgcheck'] = true
+  conf['repo_gpgcheck'] = true
+  conf['action'] = %i(add)
+  conf['newrelic_infra']['features']['host_integrations'] = false
+end

--- a/test/integration/default/inspec/host_integrations_spec.rb
+++ b/test/integration/default/inspec/host_integrations_spec.rb
@@ -4,15 +4,17 @@
 # All rights reserved.
 #
 
-describe package('newrelic-infra-integrations') do
-  it { should be_installed }
-end
+if os[:family] != 'suse'
+  describe package('newrelic-infra-integrations') do
+    it { should be_installed }
+  end
 
-describe file('/etc/newrelic-infra/integrations.d/cassandra.yaml') do
-  it { should be_file }
-  it { should be_owned_by 'newrelic_infra' }
-  it { should be_grouped_into 'newrelic_infra' }
-  its('mode') { should cmp '0640' }
-  its('content') { should match(/username: test/) }
-  its('content') { should match(/password: kitchen/) }
+  describe file('/etc/newrelic-infra/integrations.d/cassandra.yaml') do
+    it { should be_file }
+    it { should be_owned_by 'newrelic_infra' }
+    it { should be_grouped_into 'newrelic_infra' }
+    its('mode') { should cmp '0640' }
+    its('content') { should match(/username: test/) }
+    its('content') { should match(/password: kitchen/) }
+  end
 end


### PR DESCRIPTION
- Updated tests Chef client version so it has zypper support.
- Added dokken leap image to the tests(there's no other suse flavoured dokken image)
- Default conf['base_url'] is hardcoded right now because if not I was unable to test it with the dokken image. We can change it if you want.
- Disabled host-integrations test and recipe because we still don't support them.
