### PR TITLE
Suppress already initialized constant warnings for Chefspec

### DIFF
--- a/libraries/integration.rb
+++ b/libraries/integration.rb
@@ -1,7 +1,7 @@
 module NewRelicInfraCookbook
   # Chef custom resource to install the New Relic infrastructure agent on a node.
   class Integration < ::Chef::Resource
-    BASENAME_IGNORE = /(\.(t?(ar|gz|bz2?|xz)|zip))+$/
+    BASENAME_IGNORE = /(\.(t?(ar|gz|bz2?|xz)|zip))+$/ unless defined? BASENAME_IGNORE
 
     resource_name :newrelic_infra_integration
 


### PR DESCRIPTION
- Running Chefspec can give many 'already initialized constant' warnings. Suppress these à la https://github.com/chef-cookbooks/firewall/blob/master/libraries/helpers_iptables.rb.

e.g.
```shell
/var/folders/d0/2lh734r53xx8y_9r_2kvzvwdm0_f0w/T/d20180531-8278-1me0dod/cookbooks/newrelic-infra/libraries/integration.rb:4: warning: already initialized constant NewRelicInfraCookbook::Integration::BASENAME_IGNORE
/var/folders/d0/2lh734r53xx8y_9r_2kvzvwdm0_f0w/T/d20180531-8278-1me0dod/cookbooks/newrelic-infra/libraries/integration.rb:4: warning: previous definition of BASENAME_IGNORE was here
```