### PR TITLE
add strip_command_line as an agent option

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ See [attributes/defaults.rb][3] for more details and default values.
 | `default['newrelic_infra']['config']['verbose']` | `nil` | When set to 1, enables verbose logging for the agent |
 | `default['newrelic_infra']['config']['debug']` | `nil` | Enable Golang debugging |
 | `default['newrelic_infra']['config']['log_file']` | `nil` | To log to another location; when not set, the agent logs to the system log files |
+| `default['newrelic_infra']['config']['strip_command_line']` | `true` | Strip out command line parameters when displaying/querying |
 | `default['newrelic_infra']['config']['custom_attributes']` | `{}` | A hash of custom attributes to annotate the data from this agent instance |
 | `default['newrelic_infra']['agent']['config']['file']` | `agent.yaml` | File name for the agent configuration |
 | `default['newrelic_infra']['agent']['config']['mode']` | `0640` | File permissions for the agent configuration |

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -30,6 +30,8 @@ default['newrelic_infra']['config'].tap do |conf|
   conf['debug'] = nil
   # To log to another location; when not set, the agent logs to the system log files
   conf['log_file'] = nil
+  # strip the process arguments reported
+  conf['strip_command_line'] = true
   # A hash of custom attributes to annotate the data from this agent instance
   conf['custom_attributes'] = {}
 end

--- a/test/integration/default/inspec/agent_linux_spec.rb
+++ b/test/integration/default/inspec/agent_linux_spec.rb
@@ -46,6 +46,7 @@ describe file('/etc/newrelic-infra/agent.yaml') do
   its('mode') { should cmp '0640' }
   its('content') { should match(/license_key: abcd/) }
   its('content') { should match(/verbose: 0/) }
+  its('content') { should match(/strip_command_line: true/) }
 end
 
 # `poise_service` uses upstart for RHEL systems less than 7;


### PR DESCRIPTION
- missing this option to add to the agent configuration.