### PR TITLE
Replace `require_chef_omnibus` with `product_version` in .kitchen.ymls

### DIFF
--- a/.kitchen.appveyor.yml
+++ b/.kitchen.appveyor.yml
@@ -8,7 +8,7 @@ driver:
 
 provisioner:
   name: chef_zero
-  require_chef_omnibus: <%= ENV['CHEF_VERSION'] || 12 %>
+  product_version: <%= ENV['CHEF_VERSION'] || 12 %>
 
 platforms:
   - name: windows-2012r2

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -4,7 +4,7 @@ driver:
 
 provisioner:
   name: chef_zero
-  require_chef_omnibus: <%= ENV['CHEF_VERSION'] || 12 %>
+  product_version: <%= ENV['CHEF_VERSION'] || 12 %>
 
 verifier:
   name: inspec


### PR DESCRIPTION
`require_chef_omnibus` is deprecated. See https://docs.chef.io/config_yml_kitchen.html.