### PR TITLE
Prevent boolean value removal from config

### DIFF
--- a/libraries/infra_helper.rb
+++ b/libraries/infra_helper.rb
@@ -58,7 +58,7 @@ class Hash
 
   def delete_blank
     delete_if do |_, value|
-      (value.respond_to?(:empty?) ? value.empty? : !value) || value.instance_of?(Hash) && value.delete_blank.empty?
+      (value.respond_to?(:empty?) ? value.empty? : (!value if value != false)) || value.instance_of?(Hash) && value.delete_blank.empty?
     end
   end
 end


### PR DESCRIPTION
- The delete_if block for generating config removes boolean 'false' values which can have problematic results. Allow false values to remain if they are set in the config hash

previously:
```ruby
config
=> {"license_key"=>nil, "display_name"=>nil, "proxy"=>nil,
    "verbose"=>0, "debug"=>nil, "log_file"=>nil, "custom_attributes"=>{}, 
    "strip_command_line"=>false}
config.to_h.deep_stringify.delete_blank
=> {"verbose"=>0}
```

after change:
```ruby
config.to_h.deep_stringify.delete_blank
=> {"verbose"=>0, "strip_command_line"=>false}
```