### PR TITLE
Fix for centos6 docker run

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Travis CI Build Status](https://travis-ci.org/newrelic/infrastructure-agent-chef.svg?branch=master)](https://travis-ci.org/newrelic/infrastructure-agent-chef) [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/newrelic/infrastructure-agent-chef?svg=true)](https://ci.appveyor.com/project/smith37586/infrastructure-agent-chef) [![Chef Supermarket Cookbook](https://img.shields.io/cookbook/v/newrelic-infra.svg)](https://supermarket.chef.io/cookbooks/newrelic-infra)
 
-This cookbook installs and configures the New Relic Infrastructure agent as well as new Relic provided and custom on-host integrations for the Infrastructure agent can be installed. https://github.com/newrelic/infrastructure-agent-chef/pull/51
+This cookbook installs and configures the New Relic Infrastructure agent as well as new Relic provided and custom on-host integrations for the Infrastructure agent can be installed.
 See the [CHANGELOG][11] for information on the latest changes.
 
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Travis CI Build Status](https://travis-ci.org/newrelic/infrastructure-agent-chef.svg?branch=master)](https://travis-ci.org/newrelic/infrastructure-agent-chef) [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/newrelic/infrastructure-agent-chef?svg=true)](https://ci.appveyor.com/project/smith37586/infrastructure-agent-chef) [![Chef Supermarket Cookbook](https://img.shields.io/cookbook/v/newrelic-infra.svg)](https://supermarket.chef.io/cookbooks/newrelic-infra)
 
-This cookbook installs and configures the New Relic Infrastructure agent as well as new Relic provided and custom on-host integrations for the Infrastructure agent can be installed.
+This cookbook installs and configures the New Relic Infrastructure agent as well as new Relic provided and custom on-host integrations for the Infrastructure agent can be installed. https://github.com/newrelic/infrastructure-agent-chef/pull/51
 See the [CHANGELOG][11] for information on the latest changes.
 
 ## Requirements

--- a/recipes/agent_linux.rb
+++ b/recipes/agent_linux.rb
@@ -72,6 +72,13 @@ package 'newrelic-infra' do
   version node['newrelic_infra']['packages']['agent']['version'].to_s
 end
 
+# Fix for docker centos6 run
+execute 'reload_initctl_conf' do
+  command 'initctl reload-configuration'
+  only_if { node['platform_version'] =~ /^6/ }
+  only_if { ::File.exist?('/.dockerenv') }
+end
+
 # Create and manage the agent directory
 directory node['newrelic_infra']['agent']['directory']['path'] do
   owner node['newrelic_infra']['user']['name']


### PR DESCRIPTION
Currently, this cookbook does not always work with docker cento6 image.
For some reason when we install newrelic-infra on centos6 it creates upstart job - /etc/init/newrelic-infra.conf which Upstart does not pick up automatically, so we need to manually run: 

[centos@ip-10-147-84-31 ~]$ initctl reload-configuration

in order to fix this. Without this fix I am getting the following error:

* service[newrelic-infra] action enable (up to date)
    * service[newrelic-infra] action start
      
      ================================================================================
      Error executing action `start` on resource 'service[newrelic-infra]'
      ================================================================================
      
      Mixlib::ShellOut::ShellCommandFailed
      ------------------------------------
      Expected process to exit with [0], but received '1'
      ---- Begin output of /sbin/start newrelic-infra ----
      STDOUT: 
      STDERR: start: Unknown job: newrelic-infra
      ---- End output of /sbin/start newrelic-infra ----
      Ran /sbin/start newrelic-infra returned 1
      
      Cookbook Trace:
      ---------------
      /opt/kitchen/cache/cookbooks/poise-service/files/halite_gem/poise_service/service_providers/base.rb:75:in `block in action_start'
      /opt/kitchen/cache/cookbooks/poise-service/files/halite_gem/poise_service/service_providers/base.rb:136:in `notify_if_service'
      /opt/kitchen/cache/cookbooks/poise-service/files/halite_gem/poise_service/service_providers/base.rb:74:in `action_start'
      /opt/kitchen/cache/cookbooks/poise-service/files/halite_gem/poise_service/service_providers/base.rb:61:in `action_enable'
      
      Resource Declaration:
      ---------------------
      # In /opt/kitchen/cache/cookbooks/newrelic-infra/recipes/agent_linux.rb
      
       99: poise_service 'newrelic-infra' do
      100:   # TODO: Figure out how to run as a service account.
      101:   # user node['newrelic_infra']['user']['name']
      102:   command '/usr/bin/newrelic-infra ' <<
      103:           NewRelicInfra.generate_flags(node['newrelic_infra']['agent']['flags'])
      104:   options(:systemd,
      105:           template: 'newrelic-infra:default/systemd.service.erb',
      106:           after: %w(syslog.target network.target))
      107: end
      
      Compiled Resource:
      ------------------
      # Declared in /opt/kitchen/cache/cookbooks/newrelic-infra/recipes/agent_linux.rb:99:in `from_file'
      
      service("newrelic-infra") do
        provider Chef::Provider::Service::Upstart
        action [:nothing]
        default_guard_interpreter :default
        service_name "newrelic-infra"
        enabled true
        running false
        masked nil
        pattern "newrelic-infra"
        declared_type :service
        supports {:status=>true, :restart=>true, :reload=>true}
      end
      
      System Info:
      ------------
      chef_version=14.10.9
      platform=centos
      platform_version=6.10
      ruby=ruby 2.5.3p105 (2018-10-18 revision 65156) [x86_64-linux]
      program_name=/opt/chef/embedded/bin/chef-client
      executable=/opt/chef/embedded/bin/chef-client