### PR TITLE
Add options to do not remove yaml quotes

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -41,6 +41,7 @@ suites:
   - recipe[newrelic-infra::default]
   attributes:
     newrelic_infra:
+      delete_yaml_quotes: false
       features:
         host_integrations: ['nri-cassandra', 'nri-mysql', 'nri-redis', 'nri-nginx', 'nri-apache']
       config:
@@ -50,3 +51,4 @@ suites:
           cassandra:
             username: test
             password: kitchen
+            hosts: '["/"]'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This file is used to list changes made in each version of the `newrelic-infra` cookbook.
 
+## 0.11.0 (2019-07-04)
+
+IMPROVEMENTS:
+
+* Add support for disabling the removal of quotes in the generated 
+  integration definition and config files.
+
 ## 0.10.0 (2019-05-27)
 
 FEATURES:

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ See [attributes/defaults.rb][3] for more details and default values.
 | `default['newrelic_infra']['custom_integrations']` | `{}` | New Relic Infrastructure on-host custom integration configuration |
 | `default['newrelic_infra']['provider']` | `package_manager` | When `package_manager` installs the packages from yum/apt/zypp, if `tarball` installs the agent from a tarball |
 | `default['newrelic_infra']['tarball']['version']` | `nil` | the version number of the tarball to install |
+| `default['newrelic_infra']['delete_yaml_quotes']` | `true` | if true it deletes the quotes (`"`) from the generated integration configs and definitions files |
 
 ### APT repository attributes
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -6,6 +6,7 @@
 
 default['newrelic_infra']['provider'] = 'package_manager'
 default['newrelic_infra']['tarball']['version'] = nil
+default['newrelic_infra']['delete_yaml_quotes'] = true
 
 default['newrelic_infra']['tarball']['architecture'] = case node['kernel']['machine']
                                                        when 'x86_64'

--- a/libraries/infra_helper.rb
+++ b/libraries/infra_helper.rb
@@ -25,10 +25,12 @@ class Chef
         # @author Trevor G. Wood
         # @param current_contents [String] generated YAML file string
         # @return [String] YAML file with nested lists modifed
-        def yaml_file_workaround(current_contents)
+        def yaml_file_workaround(current_contents, delete_quotes)
           nested_map = current_contents[/^\-\s\w+:/] ? true : false
           regex = nested_map ? /^(\-?\s+)/ : /^(\s+\-\s)/
-          current_contents.delete!('"')
+          if delete_quotes
+            current_contents.delete!('"')
+          end
           current_contents.gsub!(regex, '  \\1')
           current_contents
         end

--- a/libraries/integration.rb
+++ b/libraries/integration.rb
@@ -116,7 +116,8 @@ module NewRelicInfraCookbook
           path file_path
           content(lazy do
             ::Chef::Recipe::NewRelicInfra.yaml_file_workaround(
-              new_resource.send(:"#{file_to_create}_content").delete_blank.deep_stringify.to_yaml
+              new_resource.send(:"#{file_to_create}_content").delete_blank.deep_stringify.to_yaml,
+              node['newrelic_infra']['delete_yaml_quotes']
             )
           end)
           sensitive true

--- a/recipes/host_integrations.rb
+++ b/recipes/host_integrations.rb
@@ -34,7 +34,8 @@ if node['newrelic_infra']['features']['host_integrations'].any?
     file file_path do
       content(lazy do
         NewRelicInfra.yaml_file_workaround(
-          config.to_h.delete_blank.deep_stringify.to_yaml
+          config.to_h.delete_blank.deep_stringify.to_yaml,
+          node['newrelic_infra']['delete_yaml_quotes']
         )
       end)
       owner node['newrelic_infra']['user']['name']

--- a/test/integration/default/inspec/host_integrations_spec.rb
+++ b/test/integration/default/inspec/host_integrations_spec.rb
@@ -3,7 +3,6 @@
 #
 # All rights reserved.
 #
-
 describe package('nri-cassandra') do
   it { should be_installed }
 end
@@ -11,7 +10,6 @@ end
 describe package('nri-mysql') do
   it { should be_installed }
 end
-
 describe package('nri-redis') do
   it { should be_installed }
 end
@@ -31,4 +29,5 @@ describe file('/etc/newrelic-infra/integrations.d/cassandra.yaml') do
   its('mode') { should cmp '0640' }
   its('content') { should match(/username: test/) }
   its('content') { should match(/password: kitchen/) }
+  its('content') { should match(%r{hosts: '\["/"\]'}) }
 end


### PR DESCRIPTION
Add an option to disable the deletion of quotes from the generated yaml file because it generates issues when specifying literal arrays of strings.

See #57 

@maximusfloydus would this work for you?