### PR TITLE
Support ARM architecture

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -11,6 +11,8 @@ default['newrelic_infra']['delete_yaml_quotes'] = true
 default['newrelic_infra']['tarball']['architecture'] = case node['kernel']['machine']
                                                        when 'x86_64'
                                                          'amd64'
+                                                       when 'aarch64'
+                                                         'arm64'
                                                        when 'i386'
                                                          '386'
                                                        else

--- a/recipes/agent_linux.rb
+++ b/recipes/agent_linux.rb
@@ -137,7 +137,7 @@ when 'tarball'
     execute 'run_installation_script' do
       command "/opt/newrelic_infra/linux_#{conf['version']}_#{conf['architecture']}/newrelic-infra/installer.sh"
       cwd "/opt/newrelic_infra/linux_#{conf['version']}_#{conf['architecture']}/newrelic-infra/"
-      environment 'NRIA_LICENSE' => node['newrelic_infra']['config']['license_key']
+      environment 'NRIA_LICENSE_KEY' => node['newrelic_infra']['config']['license_key']
       action :nothing
     end
   end


### PR DESCRIPTION
- set right tarball architecture for arm64
	- https://download.newrelic.com/infrastructure_agent/binaries/linux/arm64/
- use right environment variable for license key 
	- https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/linux-installation/tarball-assisted-install-infrastructure-agent-linux#parameters

fixes https://github.com/newrelic/infrastructure-agent-chef/issues/79