### PR TITLE
Remove poise_service and poise_archive dependency

### DIFF
--- a/.kitchen.appveyor.yml
+++ b/.kitchen.appveyor.yml
@@ -8,7 +8,7 @@ driver:
 
 provisioner:
   name: chef_zero
-  product_version: <%= ENV['CHEF_VERSION'] || 12 %>
+  product_version: <%= ENV['CHEF_VERSION'] || 15 %>
   chef_license: accept
 
 platforms:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -4,7 +4,7 @@ driver:
 
 provisioner:
   name: chef_zero
-  product_version: <%= ENV['CHEF_VERSION'] || 12 %>
+  product_version: <%= ENV['CHEF_VERSION'] || 15 %>
   chef_license: accept
 
 verifier:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -4,33 +4,38 @@ driver:
 
 provisioner:
   name: chef_zero
-  product_version: <%= ENV['CHEF_VERSION'] || 12 %>
+  # product_version: <%= ENV['CHEF_VERSION'] || 12 %>
+  product_version: 16
+  chef_license: accept
 
 verifier:
   name: inspec
 
 platforms:
-- name: centos-5
-  driver:
-    box: bento/centos-5
-- name: centos-6
-  driver:
-    box: bento/centos-6
 - name: centos-7
   driver:
     box: bento/centos-7
-- name: ubuntu-12.04
+- name: centos-8
   driver:
-    box: bento/ubuntu-12.04
-- name: ubuntu-14.04
+    box: bento/centos-8 
+- name: debian-8
   driver:
-    box: bento/ubuntu-14.04
+    box: bento/debian-8
+- name: debian-9
+  driver:
+    box: bento/debian-9
+- name: debian-10
+  driver:
+    box: bento/debian-10        
 - name: ubuntu-16.04
   driver:
     box: bento/ubuntu-16.04
 - name: ubuntu-18.04
   driver:
     box: bento/ubuntu-18.04
+- name: ubuntu-20.04
+  driver:
+    box: bento/ubuntu-20.04
 - name: windows-2012r2
   driver:
     box: mwrock/Windows2012R2

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -4,8 +4,7 @@ driver:
 
 provisioner:
   name: chef_zero
-  # product_version: <%= ENV['CHEF_VERSION'] || 12 %>
-  product_version: 16
+  product_version: <%= ENV['CHEF_VERSION'] || 12 %>
   chef_license: accept
 
 verifier:

--- a/README.md
+++ b/README.md
@@ -22,10 +22,6 @@ This cookbook installs and configures the New Relic infrastructure agent, as wel
 
 - Chef 12.15+
 
-#### Cookbooks
-
-- [poise-archive][2]
-
 ### Recipes
 
 #### `newrelic-infra::default`
@@ -284,15 +280,13 @@ To all contributors, we thank you!  Without your contribution, this project woul
 
 infrastructure-agent-chef is licensed under the [Apache 2.0](http://apache.org/licenses/LICENSE-2.0.txt) License.
 
-[1]:  https://github.com/poise/poise-service
-[2]:  https://github.com/poise/poise-archive
-[3]:  attributes/default.rb
-[4]:  https://docs.chef.io/resource_apt_repository.html
-[5]:  https://docs.chef.io/resource_yum_repository.html
-[6]:  https://docs.newrelic.com/docs/integrations/host-integrations/host-integrations-list
-[9]:  #custom-resources
-[10]: CONTRIBUTING.md
-[11]: CHANGELOG.md
-[12]: https://supermarket.chef.io/cookbooks/newrelic-infra
-[13]: metadata.rb#L10
-[14]: https://travis-ci.org/newrelic/infrastructure-agent-chef
+[1]:  attributes/default.rb
+[2]:  https://docs.chef.io/resource_apt_repository.html
+[3]:  https://docs.chef.io/resource_yum_repository.html
+[4]:  https://docs.newrelic.com/docs/integrations/host-integrations/host-integrations-list
+[5]:  #custom-resources
+[6]: CONTRIBUTING.md
+[7]: CHANGELOG.md
+[8]: https://supermarket.chef.io/cookbooks/newrelic-infra
+[9]: metadata.rb#L10
+[10]: https://travis-ci.org/newrelic/infrastructure-agent-chef

--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ This cookbook installs and configures the New Relic infrastructure agent, as wel
 * CentOS version 5 or higher
 * Debian version 7 ("Wheezy") or higher
 * Red Hat Enterprise Linux (RHEL) version 5 or higher
-* Ubuntu versions 12.04.*, 14.04.*, and 16.04.*, 18.04.* (LTS versions)
+* Ubuntu versions 16.04.*, 18.04.*, 20.04* (LTS versions)
 * Windows Server 2008, 2012, 2016, and 2019, and their service packs.
 * SUSE Linux Enterprise 11, 12
 
 #### Chef
 
-- Chef 12.15+
+- Chef 15+
 
 ### Recipes
 
@@ -82,7 +82,6 @@ See [attributes/defaults.rb][3] for more details and default values.
 
 | Name | Default value | Description |
 |:-----|:--------------|:------------|
-| `default['newrelic_infra']['features']['manage_service_account']` | `true` | Manage a local service account for running the agent |
 | `default['newrelic_infra']['features']['host_integrations']` | `[]` | List of New Relic on-host integrations |
 | `default['newrelic_infra']['user']['name']` | `newrelic_infra` | Service account user name |
 | `default['newrelic_infra']['group']['name']` | `newrelic_infra` | Service account group name |

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ This cookbook installs and configures the New Relic infrastructure agent, as wel
 
 #### Cookbooks
 
-- [poise-service][1]
 - [poise-archive][2]
 
 ### Recipes

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -49,10 +49,9 @@ end
 
 # New Relic infrastructure agent configuration file and directory properties
 default['newrelic_infra']['agent'].tap do |conf|
-  conf['config']['file'] = 'agent.yaml'
+  conf['config']['file'] = 'newrelic-infra.yml'
   conf['config']['mode'] = '0640'
-  conf['directory']['path'] = '/etc/newrelic-infra'
-  conf['directory']['mode'] = '0750'
+  conf['directory']['path'] = '/etc/'
 end
 
 # New Relic Infrastructure agent package configuration
@@ -108,7 +107,7 @@ default['newrelic_infra']['yum'].tap do |conf|
     amazon: {
       '= 2013' => 'https://download.newrelic.com/infrastructure_agent/linux/yum/el/6/x86_64',
       '> 2013.0' => 'https://download.newrelic.com/infrastructure_agent/linux/yum/el/6/x86_64',
-      '= 2' => 'https://download.newrelic.com/infrastructure_agent/linux/yum/el/7/$basearch',
+      '= 2' => 'https://download.newrelic.com/infrastructure_agent/linux/yum/el/7/x86_64',
     },
     %w(redhat oracle centos) => {
       default: "https://download.newrelic.com/infrastructure_agent/linux/yum/el/#{node['platform_version'].to_i}/x86_64",

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -107,7 +107,7 @@ default['newrelic_infra']['yum'].tap do |conf|
     amazon: {
       '= 2013' => 'https://download.newrelic.com/infrastructure_agent/linux/yum/el/6/x86_64',
       '> 2013.0' => 'https://download.newrelic.com/infrastructure_agent/linux/yum/el/6/x86_64',
-      '= 2' => 'https://download.newrelic.com/infrastructure_agent/linux/yum/el/7/x86_64',
+      '= 2' => 'https://download.newrelic.com/infrastructure_agent/linux/yum/el/7/$basearch',
     },
     %w(redhat oracle centos) => {
       default: "https://download.newrelic.com/infrastructure_agent/linux/yum/el/#{node['platform_version'].to_i}/x86_64",

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,8 +18,6 @@ default['newrelic_infra']['tarball']['architecture'] = case node['kernel']['mach
                                                        end
 
 # Feature flags
-# Whether or not to create a local service account for running the agent
-default['newrelic_infra']['features']['manage_service_account'] = true
 # Whether or not to install the New Relic on-host integrations
 default['newrelic_infra']['features']['host_integrations'] = []
 

--- a/libraries/integration.rb
+++ b/libraries/integration.rb
@@ -90,7 +90,7 @@ module NewRelicInfraCookbook
       end
 
       # Fetch the remote executable tarball if the install method is set to `tarball`
-      poise_archive new_resource.remote_url do
+      archive_file new_resource.remote_url do
         destination ::File.join(new_resource.bin_dir, new_resource.name)
         keep_existing true
         only_if { new_resource.install_method == 'tarball' }

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,12 +8,12 @@ long_description  IO.read(File.join(__dir__, 'README.md'))
 source_url        'https://github.com/newrelic/infrastructure-agent-chef'
 issues_url        'https://github.com/newrelic/infrastructure-agent-chef/issues'
 version           '0.11.0'
-chef_version      '>= 12.15'
+chef_version      '>= 15'
 
 # Platform support
 supports 'amazon', '>= 2013.0'
 supports 'debian', '>= 7.0'
-supports 'ubuntu', '>= 12.04'
+supports 'ubuntu', '>= 16.04'
 supports 'redhat', '>= 5.0'
 supports 'oracle', '>= 6.0'
 supports 'centos', '>= 5.0'

--- a/metadata.rb
+++ b/metadata.rb
@@ -19,6 +19,3 @@ supports 'oracle', '>= 6.0'
 supports 'centos', '>= 5.0'
 supports 'suse'
 supports 'windows'
-
-# Cookbook dependencies
-depends 'poise-archive', '~> 1.5'

--- a/metadata.rb
+++ b/metadata.rb
@@ -21,5 +21,4 @@ supports 'suse'
 supports 'windows'
 
 # Cookbook dependencies
-depends 'poise-service', '~> 1.5'
 depends 'poise-archive', '~> 1.5'

--- a/recipes/agent_linux.rb
+++ b/recipes/agent_linux.rb
@@ -112,8 +112,7 @@ when 'package_manager'
   service 'newrelic-infra' do
     # TODO: Figure out how to run as a service account.
     # user node['newrelic_infra']['user']['name']
-    start_command '/usr/bin/newrelic-infra ' <<
-            NewRelicInfra.generate_flags(node['newrelic_infra']['agent']['flags'])
+    start_command '/usr/bin/newrelic-infra'
     options [:systemd,
             template: 'newrelic-infra:default/systemd.service.erb',
             after: %w(syslog.target network.target)]

--- a/recipes/agent_linux.rb
+++ b/recipes/agent_linux.rb
@@ -20,6 +20,7 @@ end
 # Setup a service account
 user node['newrelic_infra']['user']['name'] do
   gid node['newrelic_infra']['group']['name']
+  shell '/bin/false'
 end
 
 # Based on the Ohai attribute `platform_family` either an APT or YUM repository
@@ -33,40 +34,31 @@ when 'package_manager'
   case node['platform_family']
   when 'debian'
     # Create APT repo file
-    apt_repository cookbook_name do |apt_resource|
-      node['newrelic_infra']['apt'].each do |property, value|
-        unless apt_resource.class.properties.include?(property.to_sym) && !value.nil? || property == 'action'
-          Chef::Log.warn("[#{cookbook_name}::#{recipe_name}] #{property} with #{value}" \
-                         'is not valid for the Chef resource `apt_repository`!')
-          next
-        end
-
-        apt_resource.send(property, value)
-      end
+    apt_repository cookbook_name do
+      arch node['newrelic_infra']['apt']['arch']
+      uri  node['newrelic_infra']['apt']['uri']
+      key  node['newrelic_infra']['apt']['key']
+      distribution node['newrelic_infra']['apt']['distribution']
+      components node['newrelic_infra']['apt']['components']
+      action node['newrelic_infra']['apt']['action']
     end
   when 'rhel', 'amazon'
-    yum_repository cookbook_name do |yum_resource|
-      node['newrelic_infra']['yum'].each do |property, value|
-        unless yum_resource.class.properties.include?(property.to_sym) && !value.nil? || property == 'action'
-          Chef::Log.warn("[#{cookbook_name}::#{recipe_name}] #{property} with #{value}" \
-                         'is not valid for the Chef resource `yum_repository`!')
-          next
-        end
-
-        yum_resource.send(property, value)
-      end
+    yum_repository cookbook_name do
+      description node['newrelic_infra']['yum']['description']
+      baseurl node['newrelic_infra']['yum']['baseurl']
+      gpgkey node['newrelic_infra']['yum']['gpgkey']
+      gpgcheck node['newrelic_infra']['yum']['gpgcheck']
+      repo_gpgcheck node['newrelic_infra']['yum']['repo_gpgcheck']
+      action node['newrelic_infra']['yum']['action']
     end
   when 'suse', 'sles'
-    zypper_repository cookbook_name do |zypper_resource|
-      node['newrelic_infra']['zypper'].each do |property, value|
-        unless zypper_resource.class.properties.include?(property.to_sym) && !value.nil? || property == 'action'
-          Chef::Log.warn("[#{cookbook_name}::#{recipe_name}] #{property} with #{value}" \
-                         'is not valid for the Chef resource `zypper_repository`!')
-          next
-        end
-
-        zypper_resource.send(property, value)
-      end
+    zypper_repository cookbook_name do
+      description node['newrelic_infra']['zypper']['description']
+      baseurl node['newrelic_infra']['zypper']['baseurl']
+      gpgkey node['newrelic_infra']['zypper']['gpgkey']
+      gpgcheck node['newrelic_infra']['zypper']['gpgcheck']
+      repo_gpgcheck node['newrelic_infra']['zypper']['repo_gpgcheck']
+      action node['newrelic_infra']['zypper']['action']
     end
   end
 

--- a/recipes/host_integrations.rb
+++ b/recipes/host_integrations.rb
@@ -42,7 +42,7 @@ if node['newrelic_infra']['features']['host_integrations'].any?
       group node['newrelic_infra']['group']['name']
       mode '0640'
       sensitive true
-      notifies :restart, 'poise_service[newrelic-infra]'
+      notifies :restart, 'service[newrelic-infra]'
     end
   end
 end

--- a/recipes/host_integrations.rb
+++ b/recipes/host_integrations.rb
@@ -14,7 +14,7 @@ if node['newrelic_infra']['features']['host_integrations'].any?
     package integration_name do
       action node['newrelic_infra']['packages'][integration_name]['action']
       retries node['newrelic_infra']['packages'][integration_name]['retries']
-      version node['newrelic_infra']['packages'][integration_name]['version'].to_s
+      version node['newrelic_infra']['packages'][integration_name]['version']
     end
   end
 

--- a/test/integration/default/inspec/agent_linux_spec.rb
+++ b/test/integration/default/inspec/agent_linux_spec.rb
@@ -34,12 +34,12 @@ end
 
 describe file('/etc/newrelic-infra') do
   it { should be_directory }
-  it { should be_owned_by 'newrelic_infra' }
-  it { should be_grouped_into 'newrelic_infra' }
-  its('mode') { should cmp '0750' }
+  it { should be_owned_by 'root' }
+  it { should be_grouped_into 'root' }
+  its('mode') { should cmp '0755' }
 end
 
-describe file('/etc/newrelic-infra/agent.yaml') do
+describe file('/etc/newrelic-infra.yml') do
   it { should be_file }
   it { should be_owned_by 'newrelic_infra' }
   it { should be_grouped_into 'newrelic_infra' }


### PR DESCRIPTION
- Removed poise_service dependency, used Chef `service` resource
- Creation of user and group by using Chef `user` and `group` resource
- Change creation of config file - removed agent.yaml and changed it to newrelic.yml to be the same as it is in https://github.com/newrelic/infrastructure-agent-puppet or https://github.com/newrelic/infrastructure-agent-ansible
- *_repositories section in agent_linux rewritten as there were issues with chef 17 +
- fixed tests
- updated kitchen.yml platforms to better represent [requirements for the infra agent](https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/get-started/requirements-infrastructure-agent/)
- tested on all platforms in kitchen.yml with chef 16 and 17 and everything seems fine :)