### PR TITLE
Remove keep_existing from archive_file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the `newrelic-infra` cookbook.
 
+## 0.12.2 (2021-10-25)
+
+* Removed keep_existing property from archive_file
+
 ## 0.12.1 (2021-09-08)
 
 FEATURES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This file is used to list changes made in each version of the `newrelic-infra` c
 ## 0.12.2 (2021-10-25)
 
 * Removed keep_existing property from archive_file
+* Uses `remote_file` to download an integration with a remote source URL and maintain a local path with `archive_file` when
+  the installation method is tarball
 
 ## 0.12.1 (2021-09-08)
 
@@ -18,16 +20,16 @@ BREAKING CHANGES:
 * The minimum supported Chef version is now 15+ instead of 12.5+.
 * Removed `poise_service` and `poise_archive` dependencies, `agent_linux.rb` rewritten to use Chef resources instead.
 * Change of creation of config file and it's location - removed `agent.yaml` and changed it to `newrelic.yml` in `/etc`.
-  
+
 ## 0.11.0 (2019-07-04)
 
 FEATURES:
 
-* Add support for Amazon Linux 2. 
+* Add support for Amazon Linux 2.
 
 IMPROVEMENTS:
 
-* Add support for disabling the removal of quotes in the generated 
+* Add support for disabling the removal of quotes in the generated
   integration definition and config files.
 
 ## 0.10.0 (2019-05-27)
@@ -35,7 +37,7 @@ IMPROVEMENTS:
 FEATURES:
 
 * Add support for installing the agent in different linux architecture from the
-  tarballs. 
+  tarballs.
 
 ## 0.9.0 (2019-03-29)
 

--- a/libraries/integration.rb
+++ b/libraries/integration.rb
@@ -89,8 +89,18 @@ module NewRelicInfraCookbook
         only_if { new_resource.install_method == 'binary' }
       end
 
+      # Fetch the remote tarball if the install method is set to 'tarball'
+      remote_file ::File.basename(new_resource.remote_url) do
+        user new_resource.user
+        group new_resource.group
+        path ::File.join(::Chef::Config['file_cache_path'], ::File.basename(new_resource.remote_url))
+        source new_resource.remote_url
+        only_if { new_resource.install_method == 'tarball' }
+      end
+
       # Unzip tarball if the install method is set to `tarball` (archive_file doesn't support remote source urls)
-      archive_file new_resource.remote_url do
+      archive_file ::File.basename(new_resource.remote_url) do
+        path ::File.join(::Chef::Config['file_cache_path'], ::File.basename(new_resource.remote_url))
         destination ::File.join(new_resource.bin_dir, new_resource.name)
         only_if { new_resource.install_method == 'tarball' }
       end

--- a/libraries/integration.rb
+++ b/libraries/integration.rb
@@ -89,10 +89,9 @@ module NewRelicInfraCookbook
         only_if { new_resource.install_method == 'binary' }
       end
 
-      # Fetch the remote executable tarball if the install method is set to `tarball`
+      # Unzip tarball if the install method is set to `tarball` (archive_file doesn't support remote source urls)
       archive_file new_resource.remote_url do
         destination ::File.join(new_resource.bin_dir, new_resource.name)
-        keep_existing true
         only_if { new_resource.install_method == 'tarball' }
       end
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description       'Installs/Configures the New Relic Infrastructure agent ' \
                   'and on-host integrations'
 source_url        'https://github.com/newrelic/infrastructure-agent-chef'
 issues_url        'https://github.com/newrelic/infrastructure-agent-chef/issues'
-version           '0.12.1'
+version           '0.12.2'
 chef_version      '>= 15'
 
 # Platform support


### PR DESCRIPTION
Description:
Resource [archive_file](https://docs.chef.io/resources/archive_file/) doesn't support `keep_existing` property and causes chef-client execution to fail.
Also, archive_file doesn't support remote urls.

Observed error:
```
Recipe: newrelic-infra::host_integrations
  * newrelic_infra_integration[dcos] action create

    ================================================================================
    Error executing action `create` on resource 'newrelic_infra_integration[dcos]'
    ================================================================================

    NoMethodError
    -------------
    undefined method `keep_existing' for Chef::Resource::ArchiveFile

    Cookbook Trace: (most recent call first)
    ----------------------------------------
    /var/chef/cache/cookbooks/newrelic-infra/libraries/integration.rb:95:in `block (2 levels) in <class:Integration>'
    /var/chef/cache/cookbooks/newrelic-infra/libraries/integration.rb:93:in `block in <class:Integration>'

    Resource Declaration:
    ---------------------
    # In /var/chef/cache/cookbooks/newrelic-infra/recipes/host_integrations.rb

     52:   newrelic_infra_integration integration_name do |infra_resource|
     53:     config.each do |property, value|
     54:       unless infra_resource.class.properties.include?(property.to_sym) && !value.nil? || property == 'action'
     55:         Chef::Log.warn("[#{cookbook_name}::#{recipe_name}] #{property} with #{value}" \
     56:                         'is not valid for the Chef resource `yum_repository`!')
     57:         next
     58:       end
     59:
     60:       infra_resource.send(property, value)
     61:     end
     62:   end

    Compiled Resource:
    ------------------
    # Declared in /var/chef/cache/cookbooks/newrelic-infra/recipes/host_integrations.rb:52:in `block in from_file'
```